### PR TITLE
Server/repository specification

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -104,6 +104,8 @@ TODO
 
 ### The Targets role {#targets_role}
 
+ <!-- TODO sub-headings about delegations -->
+
 ### The Snapshot role {#snapshot_role}
 
 ### The Timestamp role {#timestamp_role}
@@ -118,13 +120,13 @@ TODO
 
 #### Metadata about Images
 
-#### Metadata about Delegations
+#### Metadata about Delegations {#delegations}
 
 ### Snapshot Metadata {#snapshot_meta}
 
 ### Timestamp Metadata {#timestamp_meta}
 
-## Server side requirements
+## Server / repository implementation requirements
 
 An Uptane implementation SHALL make the following services available to vehicles:
 
@@ -194,82 +196,30 @@ The Time Server SHALL receive a sequence of tokens from a vehicle representing a
 
 The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
 
+## In-vehicle implementation requirements
 
-## Primary vs. Secondary Verification
+### Downloading and distributing updates on a primary ECU
 
-## Roles
+#### Construct and send vehicle version manifest {#construct_manifest}
 
-### The Root Role
+#### Download and check current time {#check_time}
 
-### The Targets Role and Delegations
+#### Download and verify metadata
 
-#### Prioritized Delegations
+#### Download and verify images
 
-#### Terminating Delegations
+#### Send latest time to secondaries
 
-#### Multi-Role Delegation
+#### Send metadata to secondaries
 
-### Delegated Targets Roles {#delegations}
+#### Send images to secondaries
 
-#### The Supplier Roles
+### Installing images on ECUs
 
-### The Snapshot Role
+### Metadata verification
 
-### The Timestamp Role
+#### Full verification
 
-### The Map File
+#### Partial verification
 
-# Metadata
-
-## Common Metadata Structures and Formats
-
-## Root Metadata
-
-## Targets Metadata
-
-### Metadata about Images
-
-### Metadata about Delegations
-
-### Example: Targets Metadata on Image and Director Repositories
-
-### Snapshot Metadata
-
-### Timestamp Metadata
-
-### Filename Conventions for Metadata or ECUs vs. repositories
-
-### The Map File
-
-### Repository Tools for Writing Metadata
-
-# Image Repository {#image_repo}
-
-# Director Repository {#director_repo}
-
-## Directing Installation of Images on Vehicles
-
-## Inventory Database 
-
-# Time server {#time_server}
-
-# Downloading, verifying, and installing updates on the vehicle
-
-## Primary ECU Download Process Overview, including Verification and Distribution to Secondaries
-
-### Construct vehicle version manifest {#construct_manifest}
-
-### Download and check time {#check_time}
-
-### Send manifest a and download metadata
-
-## How an ECU Installs a New Image
-
-## How an ECU Verifies Metadata
-
-### Partial Verification 
-
-### Full Verification 
-
-## Notes about Implementation Details
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -98,9 +98,27 @@ TODO
 
 # Detailed Design of Uptane
 
-## Repositories and Servers
+## Server side
+
+An Uptane implementation SHALL make the following services available to vehicles:
+
+* Image repository
+* Director repository
+* Time server
 
 ### Image Repository
+
+The Image repository exists to allow the OEM and/or its suppliers to upload images and their associated metadata. It makes these images and their metadata available to vehicles. The Image repository is designed to be primarily controlled by human actors, and updated relatively infrequently.
+
+The Image repository SHALL expose an interface permitting the download of metadata and images. This interface SHOULD be public.
+
+The Image repository SHALL require authorization for writing metadata and images.
+
+The Image repository SHALL provide a method for authorized users to upload images and their associated metadata. It SHALL check that a user writing metadata and images is authorized to do so for that specific image by checking the chain of delegations for the image as described in {{delegations}}.
+
+The Image repository SHALL implement storage which permits authorized users to write an image file using a unique filename, and later read the same file using the same name. It MAY use any filesystem, key-value store, or database that fulfills this requirements.
+
+The Image repository MAY require authentication for read access.
 
 ### Director Repository
 
@@ -120,7 +138,7 @@ TODO
 
 #### Multi-Role Delegation
 
-### Delegated Targets Roles
+### Delegated Targets Roles {#delegations}
 
 #### The Supplier Roles
 
@@ -154,15 +172,15 @@ TODO
 
 ### Repository Tools for Writing Metadata
 
-# Image Repository
+# Image Repository {#image_repo}
 
-# Director Repository
+# Director Repository {#director_repo}
 
 ## Directing Installation of Images on Vehicles
 
 ## Inventory Database 
 
-# Time server
+# Time server {#time_server}
 
 # Downloading, verifying, and installing updates on the vehicle
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -124,6 +124,12 @@ The Image repository MAY require authentication for read access.
 
 ### Time Server
 
+The Time Server exists to inform vehicles about the current time in cryptographically secure way, since many ECUs in a vehicle will not have a reliable source of time. It receives lists of tokens from vehicles, and returns back a signed sequence that includes the token and the current time.
+
+The Time Server SHALL receive a sequence of tokens from a vehicle representing all of its ECUs. In reponse, it SHALL sign each token together with the current time.
+
+The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
+
 ## Primary vs. Secondary Verification
 
 ## Roles
@@ -185,6 +191,8 @@ The Image repository MAY require authentication for read access.
 # Downloading, verifying, and installing updates on the vehicle
 
 ## Primary ECU Download Process Overview, including Verification and Distribution to Secondaries
+
+### Downloading and checking time {#checking_time}
 
 ## How an ECU Installs a New Image
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -98,7 +98,33 @@ TODO
 
 # Detailed Design of Uptane
 
-## Server side
+## Roles on repositories
+
+### The Root role {#root_role}
+
+### The Targets role {#targets_role}
+
+### The Snapshot role {#snapshot_role}
+
+### The Timestamp role {#timestamp_role}
+
+## Metadata abstract syntax
+
+### Common Metadata Structures and Formats
+
+### Root Metadata {#root_meta}
+
+### Targets Metadata {#targets_meta}
+
+#### Metadata about Images
+
+#### Metadata about Delegations
+
+### Snapshot Metadata {#snapshot_meta}
+
+### Timestamp Metadata {#timestamp_meta}
+
+## Server side requirements
 
 An Uptane implementation SHALL make the following services available to vehicles:
 
@@ -108,7 +134,7 @@ An Uptane implementation SHALL make the following services available to vehicles
 
 ### Image Repository
 
-The Image repository exists to allow the OEM and/or its suppliers to upload images and their associated metadata. It makes these images and their metadata available to vehicles. The Image repository is designed to be primarily controlled by human actors, and updated relatively infrequently.
+The Image repository exists to allow an OEM and/or its suppliers to upload images and their associated metadata. It makes these images and their metadata available to vehicles. The Image repository is designed to be primarily controlled by human actors, and updated relatively infrequently.
 
 The Image repository SHALL expose an interface permitting the download of metadata and images. This interface SHOULD be public.
 
@@ -116,19 +142,58 @@ The Image repository SHALL require authorization for writing metadata and images
 
 The Image repository SHALL provide a method for authorized users to upload images and their associated metadata. It SHALL check that a user writing metadata and images is authorized to do so for that specific image by checking the chain of delegations for the image as described in {{delegations}}.
 
-The Image repository SHALL implement storage which permits authorized users to write an image file using a unique filename, and later read the same file using the same name. It MAY use any filesystem, key-value store, or database that fulfills this requirements.
+The Image repository SHALL implement storage which permits authorized users to write an image file using a unique filename, and later read the same file using the same name. It MAY use any filesystem, key-value store, or database that fulfills this requirement.
 
 The Image repository MAY require authentication for read access.
 
 ### Director Repository
 
+The Director repository instructs ECUs as to which images should be installed by producing signed metadata on demand. Unlike the Image repository, it is mostly controlled by automated, online processes. It also consults a private inventory database containing information on vehicles, ECUs, and software revisions.
+
+The Directory repository SHALL expose an interface for primaries to upload vehicle version manifests and download metadata. This interface SHOULD be public.
+The Director MAY encrypt images for ECUs that require it, either by encrypting on-the-fly or by storing encrypted images in the repository.
+
+The Director repository SHALL implement storage which permits an automated service to write generated metadata files. It MAY use any filesystem, key-value store, or database that fulfills this requirement.
+
+#### Directing installation of images on vehicles
+
+A Director repository MUST conform to the following six-step process for directing the installation of software images on a vehicle.
+
+1. When the Director receives a vehicle version manifest sent by a primary (as described in {{construct_manifest}}), it decodes the manifest, and determines the unique vehicle identifier.
+1. Using the vehicle identifier, the Director queries its inventory database (as described in {{inventory_db}}) for relevant information about each ECU in the vehicle.
+1. The Director checks the manifest for accuracy compared to the information in the inventory database. If any of the required checks fail, the Director drops the request. An implementor MAY make whatever additional checks they wish. At a minimum, the following checks are required:
+    * Each ECU recorded in the inventory database is also represented in the manifest.
+    * The signature of the manifest matches the ECU key of the primary that sent it.
+    * The signature of each secondary's contribution to the manifest matches the ECU key of that secondary.
+1. The Director extracts information about currently installed images from the vehicle version manifest. Using this information, it determines which images should be installed next. The exact process by which this determination takes place is out of scope of this standard. However, it MUST take into account *dependencies* and *conflicts* between images, and SHOULD consult well-established techniques for dependency resolution.
+1. The Director MAY encrypt images for ECUs that require it.
+1. The Director generates and returns new metadata based on the dependency resolution in step 4. This includes targets ({{targets_meta}}), snapshot ({{snapshot_meta}}), and timestamp ({{timestamp_meta}}) metadata.
+
+#### Inventory Database {#inventory_db}
+
+The Director SHALL use a private inventory database to store information about ECUs and vehicles. An implementor MAY use any durable database for this purpose.
+
+The inventory database MUST record the following pieces of information:
+
+* Per vehicle:
+    * A unique identifier (such as a VIN)
+* Per ECU:
+    * A unique identifier (such as a serial number)
+    * The vehicle identifier the ECU is associated with
+    * A public key
+    * The format of the public key
+    * Whether the ECU is a primary or a secondary
+
+The inventory database MAY record other information about ECUs and vehicles.
+
 ### Time Server
 
 The Time Server exists to inform vehicles about the current time in cryptographically secure way, since many ECUs in a vehicle will not have a reliable source of time. It receives lists of tokens from vehicles, and returns back a signed sequence that includes the token and the current time.
 
-The Time Server SHALL receive a sequence of tokens from a vehicle representing all of its ECUs. In reponse, it SHALL sign each token together with the current time.
+The Time Server SHALL receive a sequence of tokens from a vehicle representing all of its ECUs. In response, it SHALL sign each token together with the current time.
 
 The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
+
 
 ## Primary vs. Secondary Verification
 
@@ -192,7 +257,11 @@ The Time Server SHALL expose a public interface allowing primaries to communicat
 
 ## Primary ECU Download Process Overview, including Verification and Distribution to Secondaries
 
-### Downloading and checking time {#checking_time}
+### Construct vehicle version manifest {#construct_manifest}
+
+### Download and check time {#check_time}
+
+### Send manifest a and download metadata
 
 ## How an ECU Installs a New Image
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -167,9 +167,9 @@ A Director repository MUST conform to the following six-step process for directi
     * Each ECU recorded in the inventory database is also represented in the manifest.
     * The signature of the manifest matches the ECU key of the primary that sent it.
     * The signature of each secondary's contribution to the manifest matches the ECU key of that secondary.
-1. The Director extracts information about currently installed images from the vehicle version manifest. Using this information, it determines which images should be installed next. The exact process by which this determination takes place is out of scope of this standard. However, it MUST take into account *dependencies* and *conflicts* between images, and SHOULD consult well-established techniques for dependency resolution.
+1. The Director extracts information about currently installed images from the vehicle version manifest. Using this information, it determines if the vehicle is already up-to-date, and if not, determines a set of images that should be installed. The exact process by which this determination takes place is out of scope of this standard. However, it MUST take into account *dependencies* and *conflicts* between images, and SHOULD consult well-established techniques for dependency resolution.
 1. The Director MAY encrypt images for ECUs that require it.
-1. The Director generates and returns new metadata based on the dependency resolution in step 4. This includes targets ({{targets_meta}}), snapshot ({{snapshot_meta}}), and timestamp ({{timestamp_meta}}) metadata.
+1. The Director generates new metadata representing the desired set of images to be installed in the vehicle, based on the dependency resolution in step 4. This includes targets ({{targets_meta}}), snapshot ({{snapshot_meta}}), and timestamp ({{timestamp_meta}}) metadata. It then sends this metadata to the primary as described in {{download_meta}}.
 
 #### Inventory Database {#inventory_db}
 
@@ -204,7 +204,7 @@ The Time Server SHALL expose a public interface allowing primaries to communicat
 
 #### Download and check current time {#check_time}
 
-#### Download and verify metadata
+#### Download and verify metadata {#download_meta}
 
 #### Download and verify images
 


### PR DESCRIPTION
I've written up the server-side components as a first pull, because they're fairly manageable as a single unit.

I've also rearranged the table of contents somewhat. The intention is to have section 4 "Detailed Design of Uptane" act as the complete normative standard, leaving out examples and explanations of motivations/principles. Those can go in other sections, to keep the normative part as tight an minimal as we possibly can; this will be very useful down the road when we're discussing and/or arbiting compliance.

I've temporarily put up the HTML version at https://static.jonoster.com/uptane-standard.html, for reviewers' convenience.
