### PR TITLE
Refactoring/fixes of PR #8

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -112,7 +112,7 @@ In order to be considered “Uptane-compliant,” an implementation MUST follow 
 
 ## Uptane Role Terminology
 
-These terms are defined in greater detail in Section 5.
+These terms are defined in greater detail in {{roles}}.
 
 *Delegations*: Designating the responsibility of signing metadata about images to another party.
 *Roles*: The roles mechanism of Uptane allows the system to distribute signing responsibilities so that the compromise of one key does not necessarily impact the security of the entire system.

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -103,11 +103,9 @@ In order to be considered “Uptane-compliant,” an implementation MUST follow 
 
 *Bus*: An internal communications network that interconnects components within a vehicle. A car can have a number of buses that will vary in terms of power, speed and resources.  
 *Image*: File containing software for an ECU to install. May contain a binary image to flash, installation instructions, and other necessary information for the ECU to properly apply the update. Each ECU typically holds only one image, although this may vary in some cases.  
-*Metadata*: Data about a file that can be used to verify its authenticity and currency, and to assure that it has not been tampered with or altered being uploaded to the repository. Metadata information is generally cryptographic hashes and file lengths.  
 *Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary ECU downloads from a repository and verifies update images and metadata for itself and for secondary ECUs, and distributes images and metadata to secondaries. Thus, it requires extra storage space and a connection to the internet. Secondary ECUs receive their update images and metadata from the primary, and only need to verify and install their own metadata and images.  
 *Repository*: A server containing metadata about images. May also contain the images themselves.  
 *Suppliers*: Independent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.  
-*Telematics Systems*: Electronic system that can remotely monitor a vehicle or its individual components.  
 *Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on all ECUs in the vehicle.  
 
 ## Uptane Role Terminology

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -73,222 +73,121 @@ This document describes a framework for securing automotive software update syst
 
 
 # Introduction
-Uptane is a secure software update framework
-for automobiles. This document describes procedures to enable
-programmers for OEMs and suppliers to design and implement this
-framework to better protect connected units on cars. Integrating
-Uptane as outlined in the sections that follow can reduce
-the ability of attackers to conpromise critical systems. It also
-assures a faster and easier recovery process should a 
-compromise occur.
 
-These instructions specify the components necessary for a 
-compliant implementation. Individual 
-implementors can make their own technological choices within those
-requirements. This flexibility makes Uptane adaptable to the
-many customized update solutions used by manufacturers.
+Uptane is a secure software update framework for automobiles. This document describes procedures to enable programmers for OEMs and suppliers to design and implement this framework to better protect connected units on cars. Integrating Uptane as outlined in the sections that follow can reduce the ability of attackers to conpromise critical systems. It also assures a faster and easier recovery process should a compromise occur.
+
+These instructions specify the components necessary for a compliant implementation. Individual implementors can make their own technological choices within those requirements. This flexibility makes Uptane adaptable to the many customized update solutions used by manufacturers.
 
 # Terminology
 
 ## Conformance Terminology
 
-The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "
-SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be 
-interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-In order to be considered “Uptane-compliant,” an 
-implementation MUST follow all of these rules as specified in the document.
+The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be  interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119). In order to be considered “Uptane-compliant,” an implementation MUST follow all of these rules as specified in the document.
 
 ## Automotive Terminology
 
-*Bus*: An internal communications network that interconnects components within
-a vehicle. A car can have a number of buses that will vary in terms of power,
-speed and resources.
-
-*Image*: File containing all the relevant data and metadata for an ECU. Each 
-ECU typically holds only one image, although this may vary in case to case.
-
-*Metadata*: Data about a file that can be used to verify its authenticity
-and currency, and to assure that it has not been tampered with or altered
-being uploaded to the repository. Metadata information is generally 
-cryptographic hashes and file lengths.
-
-*Primary/Secondary ECUs*: Terms used to describe the control units within
-an automobile. A primary control unit has more resources than a secondary,
-in terms of memory, storage space, connection to the internet, and 
-access to a time source. Primary units are updated
-directly, while secondary units are generally updated by a primary.
-
+*Bus*: An internal communications network that interconnects components within a vehicle. A car can have a number of buses that will vary in terms of power, speed and resources.
+*Image*: File containing all the relevant data and metadata for an ECU. Each ECU typically holds only one image, although this may vary in case to case.
+*Metadata*: Data about a file that can be used to verify its authenticity and currency, and to assure that it has not been tampered with or altered being uploaded to the repository. Metadata information is generally cryptographic hashes and file lengths.
+*Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary control unit has more resources than a secondary, in terms of memory, storage space, connection to the internet, and access to a time source. Primary units are updated directly, while secondary units are generally updated by a primary.
 *Repository*: Designated server containing images and metadata.
-
-*Suppliers*: Indepedent companies to which auto manufacturers may 
-outsource the production of ECUs. Tier-1 suppliers directly serve the
-manufacturers. Tier-2 suppliers are those that receive outsourced work
-from Tier-1 suppliers.
-
-*Telematics Systems*: Electronic system that can remotely monitor a vehicle
-or its individual components.
-
-*Vehicle Version Manifest*: A compilation of all ECU version manifests on
-a vehicle. It serves as a master list of all images currently
-running on alll ECUs in the vehcile.
-
+*Suppliers*: Indepedent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.
+*Telematics Systems*: Electronic system that can remotely monitor a vehicle or its individual components.
+*Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on alll ECUs in the vehcile.
 
 ## Uptane Role Terminology
 
 These terms are defined in greater detail in Section 5.
 
-*Delegations*: Designating the responsibility of signing metadata about images to another party. 
-
-*Roles*: The roles mechanism of Uptane allows
-the system to distribute signing responsibilities so that the compromise
-of one key does not necessarily impact the security of the entire system.
-
-  * *Root Role*: Distributes and revokes public keys used to 
-  verify the root, timestamp, snapshot, and targets role metadata.
-
-  * *Snapshot Role*: Indicates which images the repository has released at the
-  same time.
-  
-  * *Targets Role*: Holds the metadata used to verify the image, such as cryptographic hashes and file size.
-  
-  * *Timestamp Role*: Indicates if there are any new metadata or image 
-  on the repository.
+*Delegations*: Designating the responsibility of signing metadata about images to another party.
+*Roles*: The roles mechanism of Uptane allows the system to distribute signing responsibilities so that the compromise of one key does not necessarily impact the security of the entire system.
+    * *Root Role*: Distributes and revokes public keys used to verify the root, timestamp, snapshot, and targets role metadata.
+    * *Snapshot Role*: Indicates which images the repository has released at the same time.
+    * *Targets Role*: Holds the metadata used to verify the image, such as cryptographic hashes and file size.
+    * *Timestamp Role*: Indicates if there are any new metadata or image on the repository.
 
 
 ## Acronyms and Abbreviations
+
 *CAN Bus*: Controller Area Network bus standard.
-
 *ECUs*: Electronic Control Units, the computing units on vehicle.
-
 *LIN Bus*: Local Interconnect Bus.
-
 *SOTA*: Software Updates Over-the-Air.
-
 *VIN*: Vehicle Identification Number.
 
 # Rationale for and Scope of Uptane Standards
-This Standards document clarifies the essential components and best practices 
-for the secure design implentation and deployment of Uptane by OEMs and suppiers.
-These practices contribute to compromise resilience, or the ability
-to minimize the extent of the threat posed by any given attack.
+
+This Standards document clarifies the essential components and best practices for the secure design implentation and deployment of Uptane by OEMs and suppiers. These practices contribute to compromise resilience, or the ability to minimize the extent of the threat posed by any given attack.
 
 ## Why Uptane requires standards
-A standards document that can guide the safe design, integration and deployment of
-Uptane in cars is needed at this time because:
 
-* The number of connected units on the average vehicle continues to grow, with 
-mainstream cars now containing up to [10 million lines](https://www.usatoday.com/story/tech/columnist/2016/06/28/your-average-car-lot-more-code-driven-than-you-think/86437052/)
-of code.
+A standards document that can guide the safe design, integration and deployment of Uptane in cars is needed at this time because:
 
-* The [expanded use of software over-the-air](https://www.consumerreports.org/automotive-technology/automakers-embrace-over-the-air-updates-can-we-trust-digital-car-repair/)
-strategies creates new attack surfaces for malicious parties.
-
-* Legacy update strategies, such as SSL/TLS or GPG/RSA, are not feasible for use
-on automotive ECUs because they force manufacturers to chose between enhanced
-security and customizability.
-
-* Conventional strategies are also complicated by the differing resources of the 
-ECUs, which can vary greatly in memory, storage space, and Internet connectivity.
-
-* The design of Uptane makes it possible to offer improved design flexibility, without
-sacrificing security. 
-
-* This added design flexibility, however, could be a liability if the framework is
-implemented incorrectly.
-
-* Standardization of crucial steps in the design, implementation and use of
-Uptane can assure that customizability does not impact security or functionality.
+* The number of connected units on the average vehicle continues to grow, with mainstream cars now containing up to [10 million lines](https://www.usatoday.com/story/tech/columnist/2016/06/28/your-average-car-lot-more-code-driven-than-you-think/86437052/) of code.
+* The [expanded use of software over-the-air](https://www.consumerreports.org/automotive-technology/automakers-embrace-over-the-air-updates-can-we-trust-digital-car-repair/) strategies creates new attack surfaces for malicious parties.
+* Legacy update strategies, such as SSL/TLS or GPG/RSA, are not feasible for use on automotive ECUs because they force manufacturers to chose between enhanced security and customizability.
+* Conventional strategies are also complicated by the differing resources of the ECUs, which can vary greatly in memory, storage space, and Internet connectivity.
+* The design of Uptane makes it possible to offer improved design flexibility, without sacrificing security.
+* This added design flexibility, however, could be a liability if the framework is implemented incorrectly.
+* Standardization of crucial steps in the design, implementation and use of Uptane can assure that customizability does not impact security or functionality.
 
 ## Scope of Standards Coverage
+
 TODO
 
 ### Use Cases
+
 TODO
+
 ## Exceptions
+
 To DO
 
 ## Out of Scope
-The following topics will not be addressed in this document, as they
-represent threats outside the scope of Uptane:
 
-* Physical attacks, such as manual tampering with ECUs outside the
-vehicle.
+The following topics will not be addressed in this document, as they represent threats outside the scope of Uptane:
 
-* Compromise of the supply chain (e.g., build system, version control system, 
-packaging process). A number of strategies already (e.g., git signing, TPMs, in-toto)
-exist to address this problem. Therefore, there is no need duplicate those
-techniques here. 
-
-* Problems associated with OBD or UDS programming of ECUs, such as
-authentication of communications between ECUs.
+* Physical attacks, such as manual tampering with ECUs outside the vehicle.
+* Compromise of the supply chain (e.g., build system, version control system, packaging process). A number of strategies already (e.g., git signing, TPMs, in-toto) exist to address this problem. Therefore, there is no need duplicate those techniques here.
+* Problems associated with OBD or UDS programming of ECUs, such as authentication of communications between ECUs.
 
 ## Design Requirements
 
-The design requirements for this document are goverened by three principal
-parameters: 
+The design requirements for this document are goverened by three principal parameters:
 
-* to clearly mandate the design and implementation steps that are 
-security critical and must be followed as is, while offering flexibility
-in the implementation of non-critical steps. In this manner, users 
-can adapt to support different use models and deployment scenarios. 
-
-* to delineate best practices to ensure that, should a vehicle 
-be attacked, an attacker is forced to compromise many different
-systems.
-
-* to ensure that, if implemented, the security practices mandated or 
-suggested in this document do not interfere with the functionality
-of ECUs, vehicles, or the
-manufacturing systems on which they run.
+* to clearly mandate the design and implementation steps that are security critical and must be followed as is, while offering flexibility in the implementation of non-critical steps. In this manner, users can adapt to support different use models and deployment scenarios.
+* to delineate best practices to ensure that, should a vehicle be attacked, an attacker is forced to compromise many different systems.
+* to ensure that, if implemented, the security practices mandated or suggested in this document do not interfere with the functionality of ECUs, vehicles, or the manufacturing systems on which they run.
 
 # Threat Model and Attack Strategies
 
-The connnected units on automobiles are vulnerable to a number of 
-threats, which can be organized by attacker goals into four categories.
-These categories are presented below in order of increasing severity
-of the threat. Proper implementation of Uptane is designed to 
-prevent or minimize the impact of these strategies.
+The connnected units on automobiles are vulnerable to a number of threats, which can be organized by attacker goals into four categories. These categories are presented below in order of increasing severity of the threat. Proper implementation of Uptane is designed to prevent or minimize the impact of these strategies.
 
 ## Read updates to steal intellectual property
 
-This is generally achieved with an *Eavesdrop attack*, where attackers are 
-able to intercept and read unencrypted updates sent from the repository
-to the vehicles.
+This is generally achieved with an *Eavesdrop attack*, where attackers are able to intercept and read unencrypted updates sent from the repository to the vehicles.
 
 ## Deny updates to prevent vehicles from fixing software problems
-Attackers seeking to limit or prevent access to updates may employ a 
-number of strategies, including the following.
 
-  * *Drop-request attack:* blocks network traffic outside or inside the 
-  vehicle.
-  * *Slow retrieval attack:* slows down delivery of updates to ECUs so a 
-  known security vulnerability can be exploited before a corrective patch
-  is received.
-  * *Freeze attack:* continues to send the last known update to an ECU, 
-  even if a newer update exists.
-  * *Partial bundle installation attack:* drips traffic to selected 
-  Allows only part of an update
-  to install by dropping traffic to selected ECUs.
-  
+Attackers seeking to limit or prevent access to updates may employ anumber of strategies, including the following.
+
+* *Drop-request attack:* blocks network traffic outside or inside the vehicle.
+* *Slow retrieval attack:* slows down delivery of updates to ECUs so a known security vulnerability can be exploited before a corrective patch is received.
+* *Freeze attack:* continues to send the last known update to an ECU, even if a newer update exists.
+* *Partial bundle installation attack:* Allows only part of an update to install by dropping traffic to selected ECUs.
+ 
 ## Interfere with ECU functionality
-Attackers seeking to change the actual
-functionality of vehicle ECUs may do so in one of the following ways:
 
-  * *Rollback attack:* tricks an ECU into installing outdated software with
-  known vulnerabilities.
-  * Endless data attack: causes an ECU to crash by sending it an infinite amount
-  of data until it runs out of storage.
-  * *Mixed-bundles attack:* shuts down an ECU by causing it to install incompatible
-  versions of software updates that must not be installed at the same time. 
-  Attackers can accomplish this by showing different bundles to different 
-  ECUs at the same time.
-  * *Mix-and-match attack:* If attackers have compromised repository keys, 
-  they can use these keys to release arbitrary combinations of new versions of images.
-  
+Attackers seeking to change the actual functionality of vehicle ECUs may do so in one of the following ways:
+
+* *Rollback attack:* tricks an ECU into installing outdated software with known vulnerabilities.
+* *Endless data attack:* causes an ECU to crash by sending it an infinite amount of data until it runs out of storage.
+* *Mixed-bundles attack:* shuts down an ECU by causing it to install incompatible versions of software updates that must not be installed at the same time. Attackers can accomplish this by showing different bundles to different ECUs at the same time.
+* *Mix-and-match attack:* If attackers have compromised repository keys, they can use these keys to release arbitrary combinations of new versions of images.
+ 
 ## Control the ECU:
-The last and most severe threat is if an attack seeks to remotely control the ECU.
-The attacker can modify the vehicle’s performance through an arbitrary software
-attack, in which the software on an ECU is overwritten with a malicious software program.
+
+The last and most severe threat is if an attack seeks to remotely control the ECU. The attacker can modify the vehicle’s performance through an arbitrary software attack, in which the software on an ECU is overwritten with a malicious software program.
 
 # Detailed Design of Uptane
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -82,7 +82,9 @@ These instructions specify the components necessary for a compliant implementati
 
 ## Conformance Terminology
 
-The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be  interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119). In order to be considered “Uptane-compliant,” an implementation MUST follow all of these rules as specified in the document.
+The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be  interpreted as described in {{RFC2119}}.
+
+In order to be considered “Uptane-compliant,” an implementation MUST follow all of these rules as specified in the document.
 
 ## Automotive Terminology
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -64,6 +64,19 @@ informative:
     date: 2017-01-01
   # TODO add TUF
   # TODO add DER
+  USATODAY:
+    target: https://www.usatoday.com/story/tech/columnist/2016/06/28/your-average-car-lot-more-code-driven-than-you-think/86437052/
+    title: Your average car is a lot more code-driven than you think
+    author:
+      - ins: B. O'Donnell
+    date: 2016-06-28
+  CR-OTA:
+    target: https://www.consumerreports.org/automotive-technology/automakers-embrace-over-the-air-updates-can-we-trust-digital-car-repair/
+    title: Automakers Embrace Over-the-Air Updates, but Can We Trust Digital Car Repair?
+    author:
+      - ins: K. Barry
+    date: 2018-04-20
+
 
 --- abstract
 
@@ -125,8 +138,8 @@ This Standards document clarifies the essential components and best practices fo
 
 A standards document that can guide the safe design, integration and deployment of Uptane in cars is needed at this time because:
 
-* The number of connected units on the average vehicle continues to grow, with mainstream cars now containing up to [10 million lines](https://www.usatoday.com/story/tech/columnist/2016/06/28/your-average-car-lot-more-code-driven-than-you-think/86437052/) of code.
-* The [expanded use of software over-the-air](https://www.consumerreports.org/automotive-technology/automakers-embrace-over-the-air-updates-can-we-trust-digital-car-repair/) strategies creates new attack surfaces for malicious parties.
+* The number of connected units on the average vehicle continues to grow, with mainstream cars now containing up to 100 million lines of code. {{USATODAY}}
+* The expanded use of software over-the-air strategies creates new attack surfaces for malicious parties. {{CR-OTA}}
 * Legacy update strategies, such as SSL/TLS or GPG/RSA, are not feasible for use on automotive ECUs because they force manufacturers to chose between enhanced security and customizability.
 * Conventional strategies are also complicated by the differing resources of the ECUs, which can vary greatly in memory, storage space, and Internet connectivity.
 * The design of Uptane makes it possible to offer improved design flexibility, without sacrificing security.

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -73,30 +73,222 @@ This document describes a framework for securing automotive software update syst
 
 
 # Introduction
+Uptane is a secure software update framework
+for automobiles. This document describes procedures to enable
+programmers for OEMs and suppliers to design and implement this
+framework to better protect connected units on cars. Integrating
+Uptane as outlined in the sections that follow can reduce
+the ability of attackers to conpromise critical systems. It also
+assures a faster and easier recovery process should a 
+compromise occur.
 
-TODO
+These instructions specify the components necessary for a 
+compliant implementation. Individual 
+implementors can make their own technological choices within those
+requirements. This flexibility makes Uptane adaptable to the
+many customized update solutions used by manufacturers.
 
 # Terminology
 
 ## Conformance Terminology
 
+The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "
+SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be 
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+In order to be considered “Uptane-compliant,” an 
+implementation MUST follow all of these rules as specified in the document.
+
 ## Automotive Terminology
+
+*Bus*: An internal communications network that interconnects components within
+a vehicle. A car can have a number of buses that will vary in terms of power,
+speed and resources.
+
+*Image*: File containing all the relevant data and metadata for an ECU. Each 
+ECU typically holds only one image, although this may vary in case to case.
+
+*Metadata*: Data about a file that can be used to verify its authenticity
+and currency, and to assure that it has not been tampered with or altered
+being uploaded to the repository. Metadata information is generally 
+cryptographic hashes and file lengths.
+
+*Primary/Secondary ECUs*: Terms used to describe the control units within
+an automobile. A primary control unit has more resources than a secondary,
+in terms of memory, storage space, connection to the internet, and 
+access to a time source. Primary units are updated
+directly, while secondary units are generally updated by a primary.
+
+*Repository*: Designated server containing images and metadata.
+
+*Suppliers*: Indepedent companies to which auto manufacturers may 
+outsource the production of ECUs. Tier-1 suppliers directly serve the
+manufacturers. Tier-2 suppliers are those that receive outsourced work
+from Tier-1 suppliers.
+
+*Telematics Systems*: Electronic system that can remotely monitor a vehicle
+or its individual components.
+
+*Vehicle Version Manifest*: A compilation of all ECU version manifests on
+a vehicle. It serves as a master list of all images currently
+running on alll ECUs in the vehcile.
+
 
 ## Uptane Role Terminology
 
-## Acronyms and Abbreviation
+These terms are defined in greater detail in Section 5.
 
-# Requirements for Uptane
+*Delegations*: Designating the responsibility of signing metadata about images to another party. 
 
-## Rationale
+*Roles*: The roles mechanism of Uptane allows
+the system to distribute signing responsibilities so that the compromise
+of one key does not necessarily impact the security of the entire system.
 
-## Use Cases
+  * *Root Role*: Distributes and revokes public keys used to 
+  verify the root, timestamp, snapshot, and targets role metadata.
 
+  * *Snapshot Role*: Indicates which images the repository has released at the
+  same time.
+  
+  * *Targets Role*: Holds the metadata used to verify the image, such as cryptographic hashes and file size.
+  
+  * *Timestamp Role*: Indicates if there are any new metadata or image 
+  on the repository.
+
+
+## Acronyms and Abbreviations
+*CAN Bus*: Controller Area Network bus standard.
+
+*ECUs*: Electronic Control Units, the computing units on vehicle.
+
+*LIN Bus*: Local Interconnect Bus.
+
+*SOTA*: Software Updates Over-the-Air.
+
+*VIN*: Vehicle Identification Number.
+
+# Rationale for and Scope of Uptane Standards
+This Standards document clarifies the essential components and best practices 
+for the secure design implentation and deployment of Uptane by OEMs and suppiers.
+These practices contribute to compromise resilience, or the ability
+to minimize the extent of the threat posed by any given attack.
+
+## Why Uptane requires standards
+A standards document that can guide the safe design, integration and deployment of
+Uptane in cars is needed at this time because:
+
+* The number of connected units on the average vehicle continues to grow, with 
+mainstream cars now containing up to [10 million lines](https://www.usatoday.com/story/tech/columnist/2016/06/28/your-average-car-lot-more-code-driven-than-you-think/86437052/)
+of code.
+
+* The [expanded use of software over-the-air](https://www.consumerreports.org/automotive-technology/automakers-embrace-over-the-air-updates-can-we-trust-digital-car-repair/)
+strategies creates new attack surfaces for malicious parties.
+
+* Legacy update strategies, such as SSL/TLS or GPG/RSA, are not feasible for use
+on automotive ECUs because they force manufacturers to chose between enhanced
+security and customizability.
+
+* Conventional strategies are also complicated by the differing resources of the 
+ECUs, which can vary greatly in memory, storage space, and Internet connectivity.
+
+* The design of Uptane makes it possible to offer improved design flexibility, without
+sacrificing security. 
+
+* This added design flexibility, however, could be a liability if the framework is
+implemented incorrectly.
+
+* Standardization of crucial steps in the design, implementation and use of
+Uptane can assure that customizability does not impact security or functionality.
+
+## Scope of Standards Coverage
+TODO
+
+### Use Cases
+TODO
 ## Exceptions
+To DO
 
 ## Out of Scope
+The following topics will not be addressed in this document, as they
+represent threats outside the scope of Uptane:
+
+* Physical attacks, such as manual tampering with ECUs outside the
+vehicle.
+
+* Compromise of the supply chain (e.g., build system, version control system, 
+packaging process). A number of strategies already (e.g., git signing, TPMs, in-toto)
+exist to address this problem. Therefore, there is no need duplicate those
+techniques here. 
+
+* Problems associated with OBD or UDS programming of ECUs, such as
+authentication of communications between ECUs.
 
 ## Design Requirements
+
+The design requirements for this document are goverened by three principal
+parameters: 
+
+* to clearly mandate the design and implementation steps that are 
+security critical and must be followed as is, while offering flexibility
+in the implementation of non-critical steps. In this manner, users 
+can adapt to support different use models and deployment scenarios. 
+
+* to delineate best practices to ensure that, should a vehicle 
+be attacked, an attacker is forced to compromise many different
+systems.
+
+* to ensure that, if implemented, the security practices mandated or 
+suggested in this document do not interfere with the functionality
+of ECUs, vehicles, or the
+manufacturing systems on which they run.
+
+# Threat Model and Attack Strategies
+
+The connnected units on automobiles are vulnerable to a number of 
+threats, which can be organized by attacker goals into four categories.
+These categories are presented below in order of increasing severity
+of the threat. Proper implementation of Uptane is designed to 
+prevent or minimize the impact of these strategies.
+
+## Read updates to steal intellectual property
+
+This is generally achieved with an *Eavesdrop attack*, where attackers are 
+able to intercept and read unencrypted updates sent from the repository
+to the vehicles.
+
+## Deny updates to prevent vehicles from fixing software problems
+Attackers seeking to limit or prevent access to updates may employ a 
+number of strategies, including the following.
+
+  * *Drop-request attack:* blocks network traffic outside or inside the 
+  vehicle.
+  * *Slow retrieval attack:* slows down delivery of updates to ECUs so a 
+  known security vulnerability can be exploited before a corrective patch
+  is received.
+  * *Freeze attack:* continues to send the last known update to an ECU, 
+  even if a newer update exists.
+  * *Partial bundle installation attack:* drips traffic to selected 
+  Allows only part of an update
+  to install by dropping traffic to selected ECUs.
+  
+## Interfere with ECU functionality
+Attackers seeking to change the actual
+functionality of vehicle ECUs may do so in one of the following ways:
+
+  * *Rollback attack:* tricks an ECU into installing outdated software with
+  known vulnerabilities.
+  * Endless data attack: causes an ECU to crash by sending it an infinite amount
+  of data until it runs out of storage.
+  * *Mixed-bundles attack:* shuts down an ECU by causing it to install incompatible
+  versions of software updates that must not be installed at the same time. 
+  Attackers can accomplish this by showing different bundles to different 
+  ECUs at the same time.
+  * *Mix-and-match attack:* If attackers have compromised repository keys, 
+  they can use these keys to release arbitrary combinations of new versions of images.
+  
+## Control the ECU:
+The last and most severe threat is if an attack seeks to remotely control the ECU.
+The attacker can modify the vehicle’s performance through an arbitrary software
+attack, in which the software on an ECU is overwritten with a malicious software program.
 
 # Detailed Design of Uptane
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -102,10 +102,10 @@ In order to be considered “Uptane-compliant,” an implementation MUST follow 
 ## Automotive Terminology
 
 *Bus*: An internal communications network that interconnects components within a vehicle. A car can have a number of buses that will vary in terms of power, speed and resources.  
-*Image*: File containing all the relevant data and metadata for an ECU. Each ECU typically holds only one image, although this may vary in case to case.  
+*Image*: File containing software for an ECU to install. May contain a binary image to flash, installation instructions, and other necessary information for the ECU to properly apply the update. Each ECU typically holds only one image, although this may vary in some cases.  
 *Metadata*: Data about a file that can be used to verify its authenticity and currency, and to assure that it has not been tampered with or altered being uploaded to the repository. Metadata information is generally cryptographic hashes and file lengths.  
-*Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary control unit has more resources than a secondary, in terms of memory, storage space, connection to the internet, and access to a time source. Primary units are updated directly, while secondary units are generally updated by a primary.  
-*Repository*: Designated server containing images and metadata.  
+*Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary ECU downloads from a repository and verifies update images and metadata for itself and for secondary ECUs, and distributes images and metadata to secondaries. Thus, it requires extra storage space and a connection to the internet. Secondary ECUs receive their update images and metadata from the primary, and only need to verify and install their own metadata and images.  
+*Repository*: A server containing metadata about images. May also contain the images themselves.  
 *Suppliers*: Independent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.  
 *Telematics Systems*: Electronic system that can remotely monitor a vehicle or its individual components.  
 *Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on all ECUs in the vehicle.  

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -101,34 +101,35 @@ In order to be considered “Uptane-compliant,” an implementation MUST follow 
 
 ## Automotive Terminology
 
-*Bus*: An internal communications network that interconnects components within a vehicle. A car can have a number of buses that will vary in terms of power, speed and resources.
-*Image*: File containing all the relevant data and metadata for an ECU. Each ECU typically holds only one image, although this may vary in case to case.
-*Metadata*: Data about a file that can be used to verify its authenticity and currency, and to assure that it has not been tampered with or altered being uploaded to the repository. Metadata information is generally cryptographic hashes and file lengths.
-*Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary control unit has more resources than a secondary, in terms of memory, storage space, connection to the internet, and access to a time source. Primary units are updated directly, while secondary units are generally updated by a primary.
-*Repository*: Designated server containing images and metadata.
-*Suppliers*: Independent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.
-*Telematics Systems*: Electronic system that can remotely monitor a vehicle or its individual components.
-*Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on all ECUs in the vehicle.
+*Bus*: An internal communications network that interconnects components within a vehicle. A car can have a number of buses that will vary in terms of power, speed and resources.  
+*Image*: File containing all the relevant data and metadata for an ECU. Each ECU typically holds only one image, although this may vary in case to case.  
+*Metadata*: Data about a file that can be used to verify its authenticity and currency, and to assure that it has not been tampered with or altered being uploaded to the repository. Metadata information is generally cryptographic hashes and file lengths.  
+*Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary control unit has more resources than a secondary, in terms of memory, storage space, connection to the internet, and access to a time source. Primary units are updated directly, while secondary units are generally updated by a primary.  
+*Repository*: Designated server containing images and metadata.  
+*Suppliers*: Independent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.  
+*Telematics Systems*: Electronic system that can remotely monitor a vehicle or its individual components.  
+*Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on all ECUs in the vehicle.  
 
 ## Uptane Role Terminology
 
 These terms are defined in greater detail in {{roles}}.
 
-*Delegations*: Designating the responsibility of signing metadata about images to another party.
+*Delegations*: Designating the responsibility of signing metadata about images to another party.  
 *Roles*: The roles mechanism of Uptane allows the system to distribute signing responsibilities so that the compromise of one key does not necessarily impact the security of the entire system.
-    * *Root Role*: Distributes and revokes public keys used to verify the root, timestamp, snapshot, and targets role metadata.
-    * *Snapshot Role*: Indicates which images the repository has released at the same time.
-    * *Targets Role*: Holds the metadata used to verify the image, such as cryptographic hashes and file size.
-    * *Timestamp Role*: Indicates if there are any new metadata or image on the repository.
+
+* *Root Role*: Distributes and revokes public keys used to verify the root, timestamp, snapshot, and targets role metadata.
+* *Snapshot Role*: Indicates which images the repository has released at the same time.
+* *Targets Role*: Holds the metadata used to verify the image, such as cryptographic hashes and file size.
+* *Timestamp Role*: Indicates if there are any new metadata or image on the repository.
 
 
 ## Acronyms and Abbreviations
 
-*CAN Bus*: Controller Area Network bus standard.
-*ECUs*: Electronic Control Units, the computing units on vehicle.
-*LIN Bus*: Local Interconnect Bus.
-*SOTA*: Software Updates Over-the-Air.
-*VIN*: Vehicle Identification Number.
+*CAN Bus*: Controller Area Network bus standard.  
+*ECUs*: Electronic Control Units, the computing units on vehicle.  
+*LIN Bus*: Local Interconnect Bus.  
+*SOTA*: Software Updates Over-the-Air.  
+*VIN*: Vehicle Identification Number.  
 
 # Rationale for and Scope of Uptane Standards
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -74,7 +74,7 @@ This document describes a framework for securing automotive software update syst
 
 # Introduction
 
-Uptane is a secure software update framework for automobiles. This document describes procedures to enable programmers for OEMs and suppliers to design and implement this framework to better protect connected units on cars. Integrating Uptane as outlined in the sections that follow can reduce the ability of attackers to conpromise critical systems. It also assures a faster and easier recovery process should a compromise occur.
+Uptane is a secure software update framework for automobiles. This document describes procedures to enable programmers for OEMs and suppliers to design and implement this framework to better protect connected units on cars. Integrating Uptane as outlined in the sections that follow can reduce the ability of attackers to compromise critical systems. It also assures a faster and easier recovery process should a compromise occur.
 
 These instructions specify the components necessary for a compliant implementation. Individual implementors can make their own technological choices within those requirements. This flexibility makes Uptane adaptable to the many customized update solutions used by manufacturers.
 
@@ -91,9 +91,9 @@ The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SH
 *Metadata*: Data about a file that can be used to verify its authenticity and currency, and to assure that it has not been tampered with or altered being uploaded to the repository. Metadata information is generally cryptographic hashes and file lengths.
 *Primary/Secondary ECUs*: Terms used to describe the control units within an automobile. A primary control unit has more resources than a secondary, in terms of memory, storage space, connection to the internet, and access to a time source. Primary units are updated directly, while secondary units are generally updated by a primary.
 *Repository*: Designated server containing images and metadata.
-*Suppliers*: Indepedent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.
+*Suppliers*: Independent companies to which auto manufacturers may outsource the production of ECUs. Tier-1 suppliers directly serve the manufacturers. Tier-2 suppliers are those that receive outsourced work from Tier-1 suppliers.
 *Telematics Systems*: Electronic system that can remotely monitor a vehicle or its individual components.
-*Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on alll ECUs in the vehcile.
+*Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on all ECUs in the vehicle.
 
 ## Uptane Role Terminology
 
@@ -117,7 +117,7 @@ These terms are defined in greater detail in Section 5.
 
 # Rationale for and Scope of Uptane Standards
 
-This Standards document clarifies the essential components and best practices for the secure design implentation and deployment of Uptane by OEMs and suppiers. These practices contribute to compromise resilience, or the ability to minimize the extent of the threat posed by any given attack.
+This Standards document clarifies the essential components and best practices for the secure design implementation and deployment of Uptane by OEMs and suppliers. These practices contribute to compromise resilience, or the ability to minimize the extent of the threat posed by any given attack.
 
 ## Why Uptane requires standards
 
@@ -153,7 +153,7 @@ The following topics will not be addressed in this document, as they represent t
 
 ## Design Requirements
 
-The design requirements for this document are goverened by three principal parameters:
+The design requirements for this document are governed by three principal parameters:
 
 * to clearly mandate the design and implementation steps that are security critical and must be followed as is, while offering flexibility in the implementation of non-critical steps. In this manner, users can adapt to support different use models and deployment scenarios.
 * to delineate best practices to ensure that, should a vehicle be attacked, an attacker is forced to compromise many different systems.
@@ -161,7 +161,7 @@ The design requirements for this document are goverened by three principal param
 
 # Threat Model and Attack Strategies
 
-The connnected units on automobiles are vulnerable to a number of threats, which can be organized by attacker goals into four categories. These categories are presented below in order of increasing severity of the threat. Proper implementation of Uptane is designed to prevent or minimize the impact of these strategies.
+The connected units on automobiles are vulnerable to a number of threats, which can be organized by attacker goals into four categories. These categories are presented below in order of increasing severity of the threat. Proper implementation of Uptane is designed to prevent or minimize the impact of these strategies.
 
 ## Read updates to steal intellectual property
 
@@ -169,7 +169,7 @@ This is generally achieved with an *Eavesdrop attack*, where attackers are able 
 
 ## Deny updates to prevent vehicles from fixing software problems
 
-Attackers seeking to limit or prevent access to updates may employ anumber of strategies, including the following.
+Attackers seeking to limit or prevent access to updates may employ a number of strategies, including the following.
 
 * *Drop-request attack:* blocks network traffic outside or inside the vehicle.
 * *Slow retrieval attack:* slows down delivery of updates to ECUs so a known security vulnerability can be exploited before a corrective patch is received.


### PR DESCRIPTION
This PR does the following:

* Takes the text added by @jhdalek55 in #8, squashes all the fixup commits, and fixes the headings (48df2810120d9f29482c55f6b3c89a843d71853a)
* Applies some basic formatting fixes (60ff961dc0a1f5485b4cf32bfb969ab338f3e0b6)
* Fixes a few typos/misspellings (0327939c4abcdafbc3bbe2bce4252450e60474a4)
* Updates the standard RFC2119 blurb to the usual format and uses the correct x-ref (8c8cec9528c82894239f8086b7648924be0e7238)
* Adds the external links to media articles to the informative references, fixes the x-refs to them in the text (3bf8a0857ffbcea927b31f879af32c3d88eba8dc)
* Fixes an internal reference to another section with a proper x-ref (ccba969572810680b510d9070de8e8e9ee638ef6)