### PR TITLE
Remove hard-coded date so that draft output uses current date

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -2,7 +2,6 @@
 title: Uptane IEEE-ISTO Standard for Design and Implementation
 abbrev: UPTANE
 docname: uptane-standard-design
-date: 2018-08-28
 category: info
 
 ipr: noDerivativesTrust200902


### PR DESCRIPTION
Removing the hard-coded date makes it so that the generated output uses the current date. This way, the published drafts don't show as "expired".