### PR TITLE
Clarifies contents of timeserver time attestation

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -625,7 +625,7 @@ The Time Server exists to inform vehicles about the current time in a cryptograp
 
 An Uptane implementation SHOULD include a time server, but MAY use another secure source of time. If the time server is used, it MUST conform to the following requirements:
 
-The Time Server SHALL receive a sequence of tokens from a vehicle representing all of its ECUs. In response, it SHALL sign each token together with the current time.
+The Time Server SHALL receive a sequence of tokens from a vehicle representing all of its ECUs. In response, it SHALL return a signed response containing the sequence of tokens, together with the current time.
 
 The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -625,7 +625,7 @@ The Time Server exists to inform vehicles about the current time in a cryptograp
 
 An Uptane implementation SHOULD include a time server, but MAY use another secure source of time. If the time server is used, it MUST conform to the following requirements:
 
-The Time Server SHALL receive a sequence of tokens from a vehicle representing all of its ECUs. In response, it SHALL return a signed response containing the sequence of tokens, together with the current time.
+When the Time Server receives a sequence of tokens from a vehicle, it SHALL provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
 
 The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
 


### PR DESCRIPTION
Resolves #52 by making clear that there is one attestation containing the various tokens sent from the vehicle, along with the time (once).