### PR TITLE
Remove IETF/RFC boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 OPEN=$(word 1, $(wildcard /usr/bin/xdg-open /usr/bin/open /bin/echo))
 MKD := uptane-standard.md
 HTML := uptane-standard.html
+RAWHTML := uptane-standard-raw.html
 XML := uptane-standard.xml
 TXT := uptane-standard.txt
 
@@ -20,6 +21,8 @@ open: html ## Create an HTML version from the markdown, then open it in a browse
 
 html: xml ## Create an HTML version from the markdown
 	@xml2rfc --html $(XML) $(HTML)
+	@mv $(HTML) $(RAWHTML)
+	@cat $(RAWHTML) |sed '/<table class="header">/,/<\/table>/d;/<h1 id="rfc.status">/,/except as an Internet-Draft.<\/p>/d' > $(HTML)
 
 xml: ## Create an XML version from the markdown
 	@kramdown-rfc2629 $(MKD) > $(XML)
@@ -32,6 +35,8 @@ open-docker: html-docker ## Create an HTML version from the markdown using docke
 
 html-docker: xml-docker ## Create an HTML version from the markdown, using docker
 	@docker run --rm -it -w /workdir -v $(PWD):/workdir advancedtelematic/rfc2629 xml2rfc --html $(XML) $(HTML)
+	@mv $(HTML) $(RAWHTML)
+	@cat $(RAWHTML) |sed '/<table class="header">/,/<\/table>/d;/<h1 id="rfc.status">/,/except as an Internet-Draft.<\/p>/d' > $(HTML)
 
 xml-docker: ## Create an XML version from the markdown, using docker
 	@docker run --rm -it -w /workdir -v $(PWD):/workdir advancedtelematic/rfc2629 kramdown-rfc2629 $(MKD) > $(XML)


### PR DESCRIPTION
The generator we're using is designed for IETF RFCs and drafts. Because of that, it includes a bunch of boilerplate that doesn't really apply to Uptane at all. This commit just adds a dumb little sed script to the makefile to remove the chunks we don't want. Note that it removes it from the HTML output only, for now. If we actually care about the plaintext output, we'll need to also add post-processing there.