### PR TITLE
Refactor metadata verification into separate sections

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -827,7 +827,7 @@ If any step fails, the ECU SHALL jump to the fifth step ({{create_version_report
 
 The ECU SHALL create a version report as described in {{version_report}}, and send it to the primary (or simply save it to disk, if the ECU is a primary). The primary SHOULD write the version reports it receives to disk and associate them with the secondaries that sent them.
 
-### Metadata verification {#metadata_verification}
+### Metadata verification procedures {#metadata_verification}
 
 A primary ECU MUST perform full verification of metadata. A secondary ECU SHOULD perform full verification of metadata, but MAY perform partial verification instead.
 
@@ -859,60 +859,17 @@ In order to perform full verification, an ECU SHALL perform the following steps:
 
 1. Load the repository mapping metadata ({{repo_mapping_meta}}), and use the information therein to determine from where metadata should be downloaded.
 2. Load the latest attested time from the time server, if implemented.
-3. Download and check the Root metadata file from the Director repository:
-    1. Load the previous Root metadata file.
-    2. Update to the latest Root metadata file.
-        1. Let N denote the version number of the latest Root metadata file (which at first could be the same as the previous root metadata file).
-        2. Try downloading a new version N+1 of the Root metadata file, up to some X number of bytes. The value for X is set by the implementor. For example, X may be tens of kilobytes. The filename used to download the root metadata file is of the fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is not available, then go to step 3.5.
-        3. Version N+1 of the Root metadata file MUST have been signed by: (1) a threshold of keys specified in the latest Root metadata file (version N), and (2) a threshold of keys specified in the new Root metadata file being validated (version N+1). If version N+1 is not signed as required, discard it, abort the update cycle, and report the signature failure. On the next update cycle, begin at step 0 and version N of the root metadata file. (Checks for an arbitrary software attack.)
-        4. The version number of the latest Root metadata file (version N) must be less than or equal to the version number of the new Root metadata file (version N+1). Effectively, this means checking that the version number signed in the new Root metadata file is indeed N+1. If the version of the new Root metadata file is less than the latest metadata file, discard it, abort the update cycle, and report the rollback attack. On the next update cycle, begin at step 0 and version N of the Root metadata file. (Checks for a rollback attack.)
-        5. Set the latest Root metadata file to the new Root metadata file.
-        6. Repeat steps 1 to 6.
-    5. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
-    6. Check that the latest attested time is lower than the expiration timestamp in the latest Root metadata file. (Checks for a freeze attack.)
-    7. If the Timestamp and / or Snapshot keys have been rotated, delete the previous Timestamp and Snapshot metadata files. (Checks for recovery from fast-forward attacks {{MERCURY}}.)
-4. Download and check the Timestamp metadata file from the Director repository:
-    1. Download up to Y number of bytes. The value for Y is set by the implementor. For example, Y may be tens of kilobytes. The filename used to download the Timestamp metadata file is of the fixed form FILENAME.EXT (e.g., timestamp.json).
-    2. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. If the new timestamp metadata file is not properly signed, discard it, abort the update cycle, and report the signature failure. (Checks for an arbitrary software attack.)
-    3. Check that the version number of the previous Timestamp metadata file, if any, is less than or equal to the version number of this Timestamp metadata file. If the new Timestamp metadata file is older than the trusted Timestamp metadata file, discard it, abort the update cycle, and report the potential rollback attack. (Checks for a rollback attack.)
-    4. Check that the latest attested time is lower than the expiration timestamp in this Timestamp metadata file. If the new Timestamp metadata file has expired, discard it, abort the update cycle, and report the potential freeze attack. (Checks for a freeze attack.)
-5. Download and check the Snapshot metadata file from the Director repository:
-    1. Download up to the number of bytes specified in the Timestamp metadata file, constructing the metadata filename as defined in {{metadata_filename_rules}}.
-    2. The hashes and version number of the new Snapshot metadata file MUST match the hashes and version number listed in Timestamp metadata. If the hashes and version number do not match, discard the new Snapshot metadata, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.)
-    3. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. If the new Snapshot metadata file is not signed as required, discard it, abort the update cycle, and report the signature failure. (Checks for an arbitrary software attack.)
-    4. Check that the version number of the previous Snapshot metadata file, if any, is less than or equal to the version number of this Snapshot metadata file. If this Snapshot metadata file is older than the previous Snapshot metadata file, discard it, abort the update cycle, and report the potential rollback attack. (Checks for a rollback attack.)
-    5. Check that the version number listed by the previous Snapshot metadata file for each Targets metadata file is less than or equal to the its version number in this Snapshot metadata file. If this condition is not met, discard the new Snapshot metadata file, abort the update cycle, and report the failure. (Checks for a rollback attack.)
-    6. Check that each Targets metadata filename listed in the previous Snapshot metadata file is also listed in this Snapshot metadata file. If this condition is not met, discard the new Snapshot metadata file, abort the update cycle, and report the failure. (Checks for a rollback attack.)
-    7. Check that the latest attested time is lower than the expiration timestamp in this Snapshot metadata file. If the new Snapshot metadata file is expired, discard it, abort the update cycle, and report the potential freeze attack. (Checks for a freeze attack.)
-6. Download and check the Targets metadata file from the Director repository:
-    1. Download the number of bytes either specified in the Snapshot metadata file, or some Z number of bytes, constructing the metadata filename as defined in {{metadata_filename_rules}}. The value for Z is set by the implementor. For example, Z may be tens of kilobytes.
-    2. The hashes (if any), and version number of the new Targets metadata file MUST match the latest Snapshot metadata. If the new Targets metadata file does not match, discard it, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.)
-    3. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. (Checks for an arbitrary software attack.)
-    4. Check that the version number of the previous Targets metadata file, if any, is less than or equal to the version number of this Targets metadata file. (Checks for a rollback attack.)
-    5. Check that the latest attested time is lower than the expiration timestamp in this Targets metadata file. (Checks for a freeze attack.)
-    6. Check that there are no delegations. (Targets metadata from the director MUST NOT contain delegations.)
-    7. Check that no ECU identifier is represented more than once.
-7. Download and check the Root metadata file from the Image repository as in Step 3.
-8. Download and check the Timestamp metadata file from the Image repository as in Step 4.
-9. Download and check the Snapshot metadata file from the Image repository as in Step 5.
-10. Download and check the top-level Targets metadata file from the Image repository as in Step 6 (except for Steps 6.6-6.7).
-11. For each image listed in the Targets metadata file from the Director repository, locate a Targets metadata file that contains an image with exactly the same file name. For each delegated Targets metadata file that is found to contain metadata for the image currently being processed, perform all of the checks in step 10. Use the following process to locate image metadata.  NOTE that if at any point below, a role you attempt to check for image metadata cannot be found and verified, you should abort the search and indicate that image metadata cannot be found because of a missing or invalid role.
-    1. If the top-level Targets metadata file contains signed metadata about the image, return the metadata to be checked and skip to step 11.3.
-    2. Recursively search the list of delegations, in order of appearance:
-        1. Check whether the delegation has authority over this target. The delegation must include the hardware identifier of the target, and the target name must match one of the delegation's image paths.  If either of these tests fail, skip this delegation.
-        2. If it is a multi-role delegation {{TAP-3}}, then:
-            1. First, recurse (11.2) for each role listed as if there is a single-role delegation to each.
-            2. Inspect the return values from each:
-                1. If at least a number of roles equal to the minimum number of roles in agreement for this multi-role delegation return the same non-custom metadata (i.e. length and hashes) for the image, then return that metadata for the image. A conflict exists if there are multiple different sets of non-custom metadata with enough roles in agreement about them to meet the role threshold (for example, if the minimum number of roles in agreement is two and two sets of at least two roles agree on different metadata). To resolve such a conflict, choose the metadata returned by the set of roles that includes the earliest role in the multi-role delegation.
-                2. If the threshold for the minimum number of roles in agreement is not met:
-                    1. If this multi-role delegation is terminating, abort the search for this image by ending the recursion and returning an error code indicating that verified image metadata could not be found.
-                    2. If this multi-role delegation is not terminating, return that no image metadata was found (and continue 11.2 with the next delegation).
-        3. If the role specified by the delegation contains signed metadata about the image, return the metadata.
-        4. If the role specified by the delegation does not contain signed metadata about the image:
-            1. If this is a terminating delegation, abort the search for this image by ending the recursion and returning an error code indicating that verified image metadata could not be found.
-            2. If this is not a terminating delegation, return that no image metadata was found (and continue 11.2 with the next delegation).
-        5. If no signed metadata about the image can be found anywhere in the delegation graph, return an error code indicating that the image is missing.
-    3. Check that the Targets metadata from the Image repository matches the Targets metadata from the Director repository:
+3. Download and check the Root metadata file from the Director repository, following the procedure in {{check_root}}.
+4. Download and check the Timestamp metadata file from the Director repository, following the procedure in {{check_timestamp}}.
+5. Download and check the Snapshot metadata file from the Director repository, following the procedure in {{check_snapshot}}.
+6. Download and check the Targets metadata file from the Director repository, following the procedure in {{check_targets}}.
+7. Download and check the Root metadata file from the Image repository, following the procedure in {{check_root}}.
+8. Download and check the Timestamp metadata file from the Image repository, following the procedure in {{check_timestamp}}.
+9. Download and check the Snapshot metadata file from the Image repository, following the procedure in {{check_snapshot}}.
+10. Download and check the top-level Targets metadata file from the Image repository, following the procedure in {{check_targets}}.
+11. For each image listed in the Targets metadata file from the Director repository downloaded in step 6, complete the following procedure:
+    1. Locate and download a Targets metadata file that contains an image with exactly the same file name, following the procedure in {{resolve_delegations}}.
+    2. Check that the Targets metadata from the Image repository matches the Targets metadata from the Director repository:
         1. Check that the non-custom metadata (i.e., length and hashes) of the unencrypted image are the same in both sets of metadata.
         2. Check that the custom metadata (e.g., hardware identifier and release counter) are the same in both sets of metadata.
         3. Check that the release counter in the previous targets metadata file is less than or equal to the release counter in this targets metadata file.
@@ -920,3 +877,71 @@ In order to perform full verification, an ECU SHALL perform the following steps:
 If any step fails, the ECU MUST return an error code indicating the failure. If a check for a specific type of security attack fails (e.g. rollback, freeze, arbitrary software, etc.), the ECU SHOULD return an error code that indicates the type of attack.
 
 If the ECU performing the verification is the primary ECU, it SHOULD also ensure that the ECU identifiers present in the targets metadata from the director repository are a subset of the actual ECU identifiers of ECUs in the vehicle.
+
+#### How to check Root metadata {#check_root}
+
+1. Load the previous Root metadata file.
+2. Update to the latest Root metadata file.
+    1. Let N denote the version number of the latest Root metadata file (which at first could be the same as the previous root metadata file).
+    2. Try downloading a new version N+1 of the Root metadata file, up to some X number of bytes. The value for X is set by the implementor. For example, X may be tens of kilobytes. The filename used to download the root metadata file is of the fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is not available, the current Root metadata file is the latest; continue with step 3.
+    3. Version N+1 of the Root metadata file MUST have been signed by: (1) a threshold of keys specified in the latest Root metadata file (version N), and (2) a threshold of keys specified in the new Root metadata file being validated (version N+1). If version N+1 is not signed as required, discard it, abort the update cycle, and report the signature failure. On the next update cycle, begin at version N of the root metadata file. (Checks for an arbitrary software attack.)
+    4. The version number of the latest Root metadata file (version N) must be less than or equal to the version number of the new Root metadata file (version N+1). Effectively, this means checking that the version number signed in the new Root metadata file is indeed N+1. If the version of the new Root metadata file is less than the latest metadata file, discard it, abort the update cycle, and report the rollback attack. On the next update cycle, begin at step 0 and version N of the Root metadata file. (Checks for a rollback attack.)
+    5. Set the latest Root metadata file to the new Root metadata file.
+    6. Repeat steps 2.1 to 2.6.
+3. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
+4. Check that the latest attested time is lower than the expiration timestamp in the latest Root metadata file. (Checks for a freeze attack.)
+5. If the Timestamp and / or Snapshot keys have been rotated, delete the previous Timestamp and Snapshot metadata files. (Checks for recovery from fast-forward attacks {{MERCURY}}.)
+
+#### How to check Timestamp metadata {#check_timestamp}
+
+1. Download up to Y number of bytes. The value for Y is set by the implementor. For example, Y may be tens of kilobytes. The filename used to download the Timestamp metadata file is of the fixed form FILENAME.EXT (e.g., timestamp.json).
+2. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. If the new timestamp metadata file is not properly signed, discard it, abort the update cycle, and report the signature failure. (Checks for an arbitrary software attack.)
+3. Check that the version number of the previous Timestamp metadata file, if any, is less than or equal to the version number of this Timestamp metadata file. If the new Timestamp metadata file is older than the trusted Timestamp metadata file, discard it, abort the update cycle, and report the potential rollback attack. (Checks for a rollback attack.)
+4. Check that the latest attested time is lower than the expiration timestamp in this Timestamp metadata file. If the new Timestamp metadata file has expired, discard it, abort the update cycle, and report the potential freeze attack. (Checks for a freeze attack.)
+
+
+#### How to check Snapshot metadata {#check_snapshot}
+
+1. Download up to the number of bytes specified in the Timestamp metadata file, constructing the metadata filename as defined in {{metadata_filename_rules}}.
+2. The hashes and version number of the new Snapshot metadata file MUST match the hashes and version number listed in Timestamp metadata. If the hashes and version number do not match, discard the new Snapshot metadata, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.)
+3. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. If the new Snapshot metadata file is not signed as required, discard it, abort the update cycle, and report the signature failure. (Checks for an arbitrary software attack.)
+4. Check that the version number of the previous Snapshot metadata file, if any, is less than or equal to the version number of this Snapshot metadata file. If this Snapshot metadata file is older than the previous Snapshot metadata file, discard it, abort the update cycle, and report the potential rollback attack. (Checks for a rollback attack.)
+5. Check that the version number listed by the previous Snapshot metadata file for each Targets metadata file is less than or equal to the its version number in this Snapshot metadata file. If this condition is not met, discard the new Snapshot metadata file, abort the update cycle, and report the failure. (Checks for a rollback attack.)
+6. Check that each Targets metadata filename listed in the previous Snapshot metadata file is also listed in this Snapshot metadata file. If this condition is not met, discard the new Snapshot metadata file, abort the update cycle, and report the failure. (Checks for a rollback attack.)
+7. Check that the latest attested time is lower than the expiration timestamp in this Snapshot metadata file. If the new Snapshot metadata file is expired, discard it, abort the update cycle, and report the potential freeze attack. (Checks for a freeze attack.)
+
+#### How to check Targets metadata {#check_targets}
+
+1. Download the number of bytes either specified in the Snapshot metadata file, or some Z number of bytes, constructing the metadata filename as defined in {{metadata_filename_rules}}. The value for Z is set by the implementor. For example, Z may be tens of kilobytes.
+2. The hashes (if any), and version number of the new Targets metadata file MUST match the latest Snapshot metadata. If the new Targets metadata file does not match, discard it, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.)
+3. Check that it has been signed by the threshold of keys specified in the relevant metadata file (Checks for an arbitrary software attack):
+    1. If checking top-level targets metadata, the threshold of keys is specified in the Root metadata.
+    2. If checking delegated targets metadata, the threshold of keys is specified in the targets metadata file that delegated authority to this role.
+4. Check that the version number of the previous Targets metadata file, if any, is less than or equal to the version number of this Targets metadata file. (Checks for a rollback attack.)
+5. Check that the latest attested time is lower than the expiration timestamp in this Targets metadata file. (Checks for a freeze attack.)
+6. If checking targets metadata from the Director repository, verify that there are no delegations.
+7. If checking targets metadata from the Director repository, check that no ECU identifier is represented more than once.
+
+#### How to resolve delegations {#resolve_delegations}
+
+To properly check targets metadata for an image, an ECU MUST locate the metadata file(s) for the role (or roles) that have the authority to sign the image. This metadata might be located in the top-level targets metadata, but it also may be delegated to another role--or to multiple roles. Therefore, all delegations MUST be resolved using the following recursive procedure, beginning with the top-level targets metadata file. (Note: "Stack" here is used as defined in RFC TODO.)
+
+1. Add the current targets metadata file to the stack, and check it following the procedure in {{check_targets}}. If the file cannot be loaded, or if any verification step fails, abort the search, and indicate that image metadata cannot be found because of a missing or invalid role.
+2. If the current metadata file contains signed metadata about the image, end the search and return the metadata to be checked.
+3. If the current metadata file was reached via a terminating delegation and does not contain signed metadata about the image, abort the delegation resolution for this image and return an error indicating that image metadata could not be found.
+4. Search the list of delegations, in listed order. For each delegation:
+    1. Check if the delegation applies to the image being processed. For the delegation to apply, it MUST include the hardware identifier of the target, and the target name must match one of the delegation's image paths. If either of these tests fail, skip this delegation.
+    2. If the delegation is a multi-role delegation, follow the procedure described in {{multirole_delegations}}. If the multi-role delegation is terminating and no valid image metadata is found, abort the delegation resolution and return an error indicating that image metadata could not be found.
+    3. If the delegation is a normal delegation, add it to the stack and perform delegation resolution starting at step 1.
+    4. If the end of the list of delegations is reached without finding valid image metadata, go back to the next-highest metadata file in the stack and continue searching its list of delegations. If there are no more files in the stack (i.e. if the end of the delegations list in the top-level targets metadata file is reached), return an error indicating that image metadata could not be found.
+
+#### Multi-role delegations {#multirole_delegations}
+
+It is possible to delegate signing authority to multiple delegated roles as described in {{TAP-3}}. Each multi-role delegation effectively contains a list of ordinary delegations, plus a threshold of those roles that must be in agreement about the non-custom metadata for the image. All multi-role delegations MUST be resolved using the following procedure. Note that there may be sub-delegations inside multi-role delegations.
+
+1. For each of the roles in the delegation, find and load the image metadata (or error) following the procedure in {{resolve_delegations}}.
+2. Inspect the non-custom part of the metadata loaded in step 1:
+    1. Locate all sets of roles which have agreeing (i.e. identical) non-custom metadata. Discard any set of roles with a size smaller than the threshold of roles that must be in agreement for this delegation.
+    2. Check for a conflict. A conflict exists if there remains more than one agreeing set of roles, each set having different metadata. If a conflict is found, choose and return the metadata from the set of roles which includes the earliest role in the multi-delegation list.
+    3. If there is no conflict, check if there is any single set of roles with matching non-custom metadata. If there is, choose and return the metadata from this set.
+    4. If no agreeing set can be found that meets the agreement threshold, return an error indicating that image metadata could not be found.

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -838,14 +838,7 @@ If a step in the following workflows does not succeed (e.g., the update is abort
 In order to perform partial verification, an ECU SHALL perform the following steps:
 
 1. Load the latest attested time from the time server, if implemented.
-2. Load the latest top-level Targets metadata file from the Director repository.
-3. Check that the metadata file has been signed by a threshold of keys specified in the previous root metadata file. If not, return an error code indicating an arbitrary software attack.
-4. Check that the version number in the previous targets metadata file, if any, is less than or equal to the version number in this targets metadata file. If not, return an error code indicating a rollback attack.
-5. Check that there are no delegations. If there are, return an error code.
-6. Check that each ECU identifier appears only once. If not, return an error code.
-7. If the new Targets metadata file indicates that the Timeserver key should be rotated, then reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
-8. Check that the latest attested time is lower than the expiration timestamp in this metadata file. If not, return an error code indicating a freeze attack.
-9. Return an indicator of success.
+2. Download and check the Targets metadata file from the Director repository, following the procedure in {{check_targets}}.
 
 #### Full verification {#full_verification}
 
@@ -913,14 +906,15 @@ If the ECU performing the verification is the primary ECU, it SHOULD also ensure
 #### How to check Targets metadata {#check_targets}
 
 1. Download the number of bytes either specified in the Snapshot metadata file, or some Z number of bytes, constructing the metadata filename as defined in {{metadata_filename_rules}}. The value for Z is set by the implementor. For example, Z may be tens of kilobytes.
-2. The hashes (if any), and version number of the new Targets metadata file MUST match the latest Snapshot metadata. If the new Targets metadata file does not match, discard it, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.)
+2. The hashes (if any), and version number of the new Targets metadata file MUST match the latest Snapshot metadata. If the new Targets metadata file does not match, discard it, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.) Skip this step if checking Targets metadata on a partial-verification ECU; partial-verification ECUs will not have Snapshot metadata.
 3. Check that it has been signed by the threshold of keys specified in the relevant metadata file (Checks for an arbitrary software attack):
     1. If checking top-level targets metadata, the threshold of keys is specified in the Root metadata.
     2. If checking delegated targets metadata, the threshold of keys is specified in the targets metadata file that delegated authority to this role.
 4. Check that the version number of the previous Targets metadata file, if any, is less than or equal to the version number of this Targets metadata file. (Checks for a rollback attack.)
-5. Check that the latest attested time is lower than the expiration timestamp in this Targets metadata file. (Checks for a freeze attack.)
-6. If checking targets metadata from the Director repository, verify that there are no delegations.
-7. If checking targets metadata from the Director repository, check that no ECU identifier is represented more than once.
+5. If this Targets metadata file indicates that the Timeserver key should be rotated, then reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence). It will be updated in the next cycle.
+6. Check that the latest attested time is lower than the expiration timestamp in this Targets metadata file. (Checks for a freeze attack.)
+7. If checking targets metadata from the Director repository, verify that there are no delegations.
+8. If checking targets metadata from the Director repository, check that no ECU identifier is represented more than once.
 
 #### How to resolve delegations {#resolve_delegations}
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -918,16 +918,16 @@ If the ECU performing the verification is the primary ECU, it SHOULD also ensure
 
 #### How to resolve delegations {#resolve_delegations}
 
-To properly check targets metadata for an image, an ECU MUST locate the metadata file(s) for the role (or roles) that have the authority to sign the image. This metadata might be located in the top-level targets metadata, but it also may be delegated to another role--or to multiple roles. Therefore, all delegations MUST be resolved using the following recursive procedure, beginning with the top-level targets metadata file. (Note: "Stack" here is used as defined in RFC TODO.)
+To properly check targets metadata for an image, an ECU MUST locate the metadata file(s) for the role (or roles) that have the authority to sign the image. This metadata might be located in the top-level targets metadata, but it also may be delegated to another role--or to multiple roles. Therefore, all delegations MUST be resolved using the following recursive procedure, beginning with the top-level targets metadata file.
 
-1. Add the current targets metadata file to the stack, and check it following the procedure in {{check_targets}}. If the file cannot be loaded, or if any verification step fails, abort the search, and indicate that image metadata cannot be found because of a missing or invalid role.
-2. If the current metadata file contains signed metadata about the image, end the search and return the metadata to be checked.
+1. Download the current metadata file, and check it following the procedure in {{check_targets}}. If the file cannot be loaded, or if any verification step fails, abort the delegation resolution, and indicate that image metadata cannot be found because of a missing or invalid role.
+2. If the current metadata file contains signed metadata about the image, end the delegation resolution and return the metadata to be checked.
 3. If the current metadata file was reached via a terminating delegation and does not contain signed metadata about the image, abort the delegation resolution for this image and return an error indicating that image metadata could not be found.
 4. Search the list of delegations, in listed order. For each delegation:
-    1. Check if the delegation applies to the image being processed. For the delegation to apply, it MUST include the hardware identifier of the target, and the target name must match one of the delegation's image paths. If either of these tests fail, skip this delegation.
+    1. Check if the delegation applies to the image being processed. For the delegation to apply, it MUST include the hardware identifier of the target, and the target name must match one of the delegation's image paths. If either of these tests fail, move on to the next delegation in the list.
     2. If the delegation is a multi-role delegation, follow the procedure described in {{multirole_delegations}}. If the multi-role delegation is terminating and no valid image metadata is found, abort the delegation resolution and return an error indicating that image metadata could not be found.
-    3. If the delegation is a normal delegation, add it to the stack and perform delegation resolution starting at step 1.
-    4. If the end of the list of delegations is reached without finding valid image metadata, go back to the next-highest metadata file in the stack and continue searching its list of delegations. If there are no more files in the stack (i.e. if the end of the delegations list in the top-level targets metadata file is reached), return an error indicating that image metadata could not be found.
+    3. If the delegation is a normal delegation, perform delegation resolution, starting at step 1. Note that this may recurse an arbitrary number of levels deep. If a delegation that applies to the image is found but no image metadata is found in the delegated roles or any of its sub-delegations, simply continue on with the next delegation in the list. The search is only completed/aborted if image metadata or a terminating delegation that applies to the image is found.
+5. If the end of the list of delegations in the top-level metadata is reached without finding valid image metadata, return an error indicating that image metadata could not be found.
 
 #### Multi-role delegations {#multirole_delegations}
 


### PR DESCRIPTION
This is a pretty big refactor, and in fact changes the structure of how the delegation resolution search is described. @trishankatdatadog, @awwad: can you take a close look?