### PR TITLE
Add simple guidance on repo mapping metadata

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -633,6 +633,8 @@ Each ECU in a vehicle receiving over-the-air updates is either a primary or a se
 
 All ECUs MUST verify image metadata as specified in {{metadata_verification}} before installing an image or making it available to other ECUs. A primary ECU MUST perform full verification ({{full_verification}}). A secondary ECU SHOULD perform full verification if possible. See [Uptane Deployment Considerations](#DEPLOY) for a discussion of how to choose between partial and full verification.
 
+ECUs MUST have a secure source of time. The Uptane deployment considerations ({{DEPLOY}}) describe one way to implement an external time server to cryptographically attest time, but any other source of time that the OEM or Uptane implementor considers to be secure MAY be used. When "loading time" is referenced in procedures in this standard, it should be understood to mean loading into memory the current time (if the ECU has its own secure clock), or the most recent attested time.
+
 ### Build-time prerequisite requirements for ECUs
 
 For an ECU to be capable of receiving Uptane-secured updates, it MUST have the following data provisioned at the time it is manufactured or installed in the vehicle:

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -529,7 +529,7 @@ The Timestamp metadata SHALL contain the following information:
 
 As described in the introduction to {{design}}, Uptane requires a Director repository and an Image repository. However, it is possible to have an Uptane-compliant implementation that has more than two repositories.
 
-Repository mapping metadata informs a primary ECU about which repositories to trust for images or image paths. {{TAP-4}} describes how to make use of more complex repository mapping metadata have more than the two required repositories.
+Repository mapping metadata informs a primary ECU about which repositories to trust for images or image paths. {{TAP-4}} describes how to make use of more complex repository mapping metadata, to have more than the two required repositories.
 
 Repository mapping metadata, or the equivalent informational content, MUST be present on all primary ECUs, and MUST contain the following information:
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -633,7 +633,7 @@ Each ECU in a vehicle receiving over-the-air updates is either a primary or a se
 
 All ECUs MUST verify image metadata as specified in {{metadata_verification}} before installing an image or making it available to other ECUs. A primary ECU MUST perform full verification ({{full_verification}}). A secondary ECU SHOULD perform full verification if possible. See [Uptane Deployment Considerations](#DEPLOY) for a discussion of how to choose between partial and full verification.
 
-ECUs MUST have a secure source of time. The Uptane deployment considerations ({{DEPLOY}}) describe one way to implement an external time server to cryptographically attest time, but any other source of time that the OEM or Uptane implementor considers to be secure MAY be used. When "loading time" is referenced in procedures in this standard, it should be understood to mean loading into memory the current time (if the ECU has its own secure clock), or the most recent attested time.
+ECUs MUST have a secure source of time. An OEM/Uptane implementor MAY use any external source of time that is demonstrably secure. The Uptane deployment considerations ({{DEPLOY}}) describe one way to implement an external time server to cryptographically attest time, as well as the security properties required. When "loading time" is referenced in procedures in this standard, it should be understood to mean loading into memory the current time (if the ECU has its own secure clock), or the most recent attested time.
 
 ### Build-time prerequisite requirements for ECUs
 


### PR DESCRIPTION
Closes #53.

I also added a short paragraph on time, because many procedures still reference loading secure attestations of time, and the full time server procedure was removed in #104.