### PR TITLE
Addressing Issue #116 and one item in issue #119

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -161,11 +161,11 @@ This document describes a framework for securing ground vehicle software update 
 
 Uptane is a secure software update framework for ground vehicles. This document describes procedures to enable programmers for OEMs and suppliers to securely design and implement this framework in a manner that better protects connected units on ground vehicles. Integrating Uptane as outlined in the sections that follow can reduce the ability of attackers to compromise critical systems. It also assures a faster and easier recovery process should a compromise occur.
 
-These instructions specify the components necessary for a compliant implementation. Individual implementors can make their own technological choices within those requirements. This flexibility makes Uptane adaptable to the many customized update solutions used by manufacturers. If implementors wish to have compatible formats, they may use POUFs. POUFs contain a description of implementation choices as well as data binding formats. An implementor who follows a POUF, as well as the Uptane standard, will be able to interoperate with other implementations using that POUF.
+These instructions specify the components necessary for a compliant implementation. Individual implementors can make their own technological choices within those requirements. This flexibility makes Uptane adaptable to the many customized update solutions used by manufacturers. If implementors wish to have compatible formats, they may use POUFs. POUFs contain a description of implementation choices as well as data binding formats. An implementor who adopts a POUF, as well as the Uptane Standard, will be able to interoperate with other implementations using that POUF.
 
 # Terminology
 
-## Conformance Terminology
+## Conformance terminology
 
 The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in {{RFC2119}}.
 
@@ -185,6 +185,10 @@ In order to be considered “Uptane-compliant,” an implementation MUST follow 
 
 *Image*: File containing software for an ECU to install. May contain a binary image to flash, installation instructions, and other necessary information for the ECU to properly apply the update. Each ECU typically holds only one image, although this may vary in some cases.  
 
+*Metadata*:  Information describing the characteristics of data including, for example, structural
+metadata describing data structures (e.g., data format, syntax, and semantics) and
+descriptive metadata describing data contents (e.g., information security labels). As used in Uptane, metadata can be described as information associated with a role or an image that contains the characteristics or parameters thereof (e.g. cryptographic material parameters, file names and versions.)
+
 *Primary/Secondary ECUs*: Terms used to describe the control units within a ground vehicle. A primary ECU downloads and verifies update images and metadata for itself and for secondary ECUs, and distributes images and metadata to secondaries. Thus, it requires extra storage space and a means to download images and metadata.  Secondary ECUs receive their update images and metadata from the primary, and only need to verify and install their own metadata and images.
 
 *POUF*: A document that contains the protocol, operations, usage, and formats (POUF) of a specific Uptane implementation. The POUF contains decisions about SHOULDs and MAYs in an implementation, as well as descriptions of data binding formats. POUFs MAY be used to create compatible Uptane implementations.
@@ -195,7 +199,7 @@ In order to be considered “Uptane-compliant,” an implementation MUST follow 
 
 *Vehicle Version Manifest*: A compilation of all ECU version manifests on a vehicle. It serves as a master list of all images currently running on all ECUs in the vehicle.  
 
-## Uptane Role Terminology
+## Uptane Role terminology
 
 These terms are defined in greater detail in {{roles}}.
 
@@ -208,25 +212,31 @@ These terms are defined in greater detail in {{roles}}.
 * *Timestamp Role*: Signs metadata that indicates if there are any new metadata or images on the repository.
 
 
-## Acronyms and Abbreviations
+## Acronyms and abbreviations
 
 *CAN Bus*: Controller Area Network bus standard  
+
+*CDN*: Content Delivery Network 
 
 *ECUs*: Electronic Control Units, the computing units on a vehicle
 
 *LIN Bus*: Local Interconnect Bus
 
+*OBD*: On-board diagnostics 
+
 *SOTA*: Software Updates Over-the-Air  
+
+*UDS*: Unified Diagnostic Services
 
 *VIN*: Vehicle Identification Number
 
-# Rationale for and Scope of Uptane Standards
+# Rationale for and scope of Uptane Standards
 
 This Standards document clarifies the essential components and best practices for the secure design, implementation and deployment of Uptane by OEMs and suppliers. These practices contribute to compromise resilience, or the ability to minimize the extent of the threat posed by any given attack.
 
-However, this specification is intended as an implementation guide, not as a detailed technical argument about the security properties that Uptane provides.  Readers interested in such documentation should refer to published papers that cover this topic.  {{UPTANEESCAR}}
+However, this specification is intended as an implementation guide, and not as a detailed technical argument about the security properties that Uptane provides.  Readers interested in such documentation should refer to published papers that cover this topic.  {{UPTANEESCAR}}
 
-## Why Uptane requires standards
+## Why Uptane requires a standards document
 
 A standards document that can guide the safe design, integration and deployment of Uptane in vehicles is needed at this time because:
 
@@ -238,23 +248,23 @@ A standards document that can guide the safe design, integration and deployment 
 * This added design flexibility, however, could be a liability if the framework is implemented incorrectly.
 * Standardization of crucial steps in the design, implementation and use of Uptane can assure that customizability does not impact security or functionality.
 
-## Scope of Standards Coverage
+## Scope of Standards coverage
 
-This document sets guidelines for implementing Uptane in most systems capable of updating software on connected units in ground vehicles, including passenger vehicles, light-duty trucks, heavy-duty trucks, and motorcycles. Uptane could potentially also be applied to other ground vehicles such as automated shuttles, recreational vehicles, and military ground vehicles, and Uptane could even be applied to domains such as IoT devices, medical devices, and UAVs. In this section, we define the scope of that applicability by providing sample use cases and possible exceptions, aspects of update security that are not applicable to Uptane, and the design requirements governing the preparation of these standards.
+This document sets guidelines for implementing Uptane in most systems capable of updating software on connected units in ground vehicles, including passenger vehicles, light-duty trucks, heavy-duty trucks, and motorcycles. Uptane could potentially also be applied to other ground vehicles, such as automated shuttles, recreational vehicles, and military ground vehicles. Uptane could even be applied to domains such as IoT devices, medical devices, and unmanned aerial vehicles. In this section, we define the scope of that applicability by providing sample use cases and possible exceptions, aspects of software update security that are not applicable to Uptane, and the design requirements governing the preparation of these standards.
 
 ### Assumptions
 
 We assume the following system preconditions for Uptane:
 
 * Vehicles have the ability to establish connectivity to required backend services. For example, this could be done through cellular, Wi-Fi, or hard-wired mechanisms.
-* ECUs are either directly connected to the communication channel, or they are indirectly connected via some sort of network gateway.
+* ECUs are either directly connected to the communication channel, or are indirectly connected via some sort of network gateway.
 * ECUs are programmable and provide sufficient performance to be updated.
 * ECUs must be able to perform a public key cryptography operation as well as some supporting operations.
-* There are state-of-the-art secure servers in place, such as the director and image repository servers.
+* There are state-of-the-art secure servers in place, such as the Director and Image repository servers.
 
 It is important that any bugs detected in Uptane implementations be patched promptly. Failure to do so could interfere with the effectiveness of Uptane's operations.
 
-### Use Cases
+### Use cases
 
 The following use cases provide a number of scenarios illustrating the manner in which software updates could be accomplished using Uptane.
 
@@ -276,7 +286,7 @@ An OEM has issued a recall to address a problem with a keyless entry device that
 
 #### Update one ECU with multiple deltas
 
-The OEM wants to use delta updates to save over-the-air bytes. The delta images contain only the code and/or data that has changed from the previous image version. To do so, the OEM must first modify the director repository, using the vehicle version manifest and dependency resolution to determine the differences between the previous and latest images. The OEM then adds the following to the custom targets metadata used by the director repository: (1) the algorithm used to apply a delta image, and (2) the targets metadata about the delta image. The OEM will also check whether the delta images match the targets metadata from the director repository.
+The OEM wants to use delta updates to save over-the-air bytes. The delta images contain only the code and/or data that has changed from the previous image version. To do so, the OEM must first modify the Director repository, using the vehicle version manifest and dependency resolution to determine the differences between the previous and latest images. The OEM then adds the following to the custom Targets metadata used by the Director repository: (1) the algorithm used to apply a delta image, and (2) the Targets metadata about the delta image. The OEM will also check whether the delta images match the Targets metadata from the Director repository.
 
 ## Exceptions
 
@@ -299,7 +309,7 @@ The following topics will not be addressed in this document, as they represent t
 * Problems associated with OBD or UDS programming of ECUs, such as authentication of communications between ECUs.
 * Malicious mirrors of package repositories, which may substitute original packages with malicious packages with matching version numbers {{MERCURY}}.
 
-## Design Requirements
+## Design requirements
 
 The design requirements for this document are governed by the following principal parameters:
 
@@ -307,9 +317,9 @@ The design requirements for this document are governed by the following principa
 * to ensure that, if Uptane is implemented, the security practices mandated or suggested in this document do not interfere with the functionality of ECUs, vehicles, or the systems that maintain them.
 * to delineate best practices to ensure that, should any part of the SOTA mechanism of a vehicle be attacked, an attacker must compromise two or more modules to breach the SOTA mechanism.
 
-# Threat Model and Attack Strategies
+# Threat model and attack strategies
 
-The overarching goal of Uptane is to provide a system that is resilient in the face of various types of compromise. In this section, we describe the goals that an attacker may have ({{attacker_goals}}) and the capabilities they may have or could develop ({{capabilities}}). We then describe and classify types of attacks on the system according to the attacker's goals ({{threats}}).
+The overarching goal of Uptane is to provide a system that is resilient in the face of various types of compromise. In this section, we describe the goals an attacker may have ({{attacker_goals}}) and the capabilities they may have or could develop ({{capabilities}}). We then describe and classify types of attacks on the system according to the attacker's goals ({{threats}}).
 
 ## Attacker goals {#attacker_goals}
 
@@ -327,8 +337,8 @@ Uptane is designed with resilience to compromise in mind. We assume that attacke
 * Intercept and modify network traffic (i.e., perform man-in-the-middle attacks). This capability may be developed in two domains:
     * Outside the vehicle, intercepting and modifying traffic between the vehicle and software repositories
     * Inside the vehicle, intercepting and modifying traffic on one or more vehicle buses (e.g. via an OBD port or using a compromised ECU as a vector)
-* Compromise and control either a director repository or image repository server, and any keys stored on the repository, but not both the director and image repositories.
-* Compromise either a primary ECU or a secondary ECU, but not both in the same vehicle
+* Compromise and control either a Director repository or Image repository server, and any keys stored on that repository, but not both the Director and Image repositories.
+* Compromise either a Primary ECU or a Secondary ECU, but not both in the same vehicle
 
 ## Description of threats {#threats}
 
@@ -362,15 +372,15 @@ Full control of a vehicle, or one or more ECUs within a vehicle, is the most sev
 
 * *Arbitrary software attack:* Cause an ECU to install and run arbitrary code of the attacker's choice.
 
-# Detailed Design of Uptane {#design}
+# Detailed design of Uptane {#design}
 
 Uptane is a secure software update framework for automobiles. We do not specify implementation details. Instead, we describe the components necessary for a compliant implementation and leave it up to individual implementors to make their own technological choices within those requirements.
 
 At a high level, Uptane requires:
 
 * Two software repositories:
-    * An image repository containing binary images to install, and signed metadata about those images
-    * A director repository connected to an inventory database that can sign metadata on demand for images in the image repository
+    * An Image repository containing binary images to install, and signed metadata about those images
+    * A Director repository connected to an inventory database that can sign metadata on demand for images in the Image repository
 * Repository tools for generating Uptane-specific metadata about images
 * A public key infrastructure supporting the required metadata production/signing roles on each repository:
     * Root - Certificate authority for the Uptane ecosystem. Distributes public keys for verifying all the other roles' metadata
@@ -379,8 +389,8 @@ At a high level, Uptane requires:
     * Targets - Indicates metadata about images, such as hashes and file sizes
 * A secure way for ECUs to know the time.
 * An ECU capable of downloading images and associated metadata from the Uptane servers.
-* An in-vehicle client on a primary ECU capable of verifying the signatures on all update metadata and downloading updates on behalf of its associated secondary ECUs. The primary ECU MAY be the same ECU that communicates with the server.
-* A client or library on each secondary ECU capable of performing either full or partial verification of metadata
+* An in-vehicle client on a Primary ECU capable of verifying the signatures on all update metadata and downloading updates on behalf of its associated Secondary ECUs. The primary ECU MAY be the same ECU that communicates with the server.
+* A client or library on each Secondary ECU capable of performing either full or partial verification of metadata
 
 ## Roles on repositories {#roles}
 
@@ -403,15 +413,15 @@ The Targets role on the Image repository MAY delegate the responsibility of sign
 
 Responsibility for signing images or a subset of images MAY be delegated to more than one role and therefore it is possible for two different roles to be trusted for signing a particular image. For this reason, delegations MUST be prioritized.
 
-A particular delegation for a subset of images MAY be designated as **terminating**. For terminating delegations, the client SHALL NOT search any further if it does not find validly signed metadata about those images in the terminating delegation. Delegations SHOULD NOT be terminating by default; terminating delegations SHOULD only be used when there is a compelling technical reason to do so.
+A particular delegation for a subset of images MAY be designated as **terminating**. For terminating delegations, the client SHALL NOT search any further if it does not find validly signed metadata about those images. Delegations SHOULD NOT be terminating by default; terminating delegations SHOULD only be used when there is a compelling technical reason to do so.
 
-A delegation for a subset of images MAY be a multi-role delegation {{TAP-3}}. A multi-role delegation indicates that multiple roles are needed to sign a particular image and so each of the delegatee roles MUST sign the same metadata.
+A delegation for a subset of images MAY be a multi-role delegation {{TAP-3}}. A multi-role delegation indicates that multiple roles are needed to sign a particular image and each of the delegatee roles MUST sign the same metadata.
 
 Delegations only apply to the Image repository. The Targets role on the Director repository MUST NOT delegate metadata signing responsibility.
 
 ### The Snapshot role {#snapshot_role}
 
-A repository's Snapshot role SHALL produce and sign metadata about all Targets metadata the repository releases, including the current version number of the top-level Targets metadata, and the version numbers of all delegated targets metadata, as described in {{snapshot_meta}}.
+A repository's Snapshot role SHALL produce and sign metadata about all Targets metadata the repository releases, including the current version number of the top-level Targets metadata, and the version numbers of all delegated Targets metadata, as described in {{snapshot_meta}}.
 
 ### The Timestamp role {#timestamp_role}
 
@@ -425,7 +435,7 @@ However, string comparison is required as part of metadata verification. To ensu
 
 In the Deployment Considerations document, the Uptane Alliance provides some examples of compliant metadata structures in ASN.1 and JSON.
 
-### Common Metadata Structures {#common_metadata}
+### Common metadata structures {#common_metadata}
 
 Every public key MUST be represented using a public key identifier.  A public key identifier is EITHER all of the following:
 
@@ -451,7 +461,7 @@ The payload differs depending on the role. However, the payload for all roles sh
 
 The following sections describe the role-specific metadata. All roles SHALL follow the common structures described here.
 
-### Root Metadata {#root_meta}
+### Root metadata {#root_meta}
 
 A repository's Root metadata distributes the public keys of the top-level Root, Targets, Snapshot, and Timestamp roles, as well as revocations of those keys. It SHALL contain two attributes:
 
@@ -460,15 +470,15 @@ A repository's Root metadata distributes the public keys of the top-level Root, 
 
 Additionally, it MAY contain a mapping of roles to a list of valid URLs from which the role metadata can be downloaded.  If this mapping of URLs is used, the implementer SHOULD implement this functionality following {{TAP-5}} to avoid adding unforeseen security risks.
 
-### Targets Metadata {#targets_meta}
+### Targets metadata {#targets_meta}
 
-The Targets metadata on a repository contains all of the information about images to be installed on ECUs. This includes filenames, hashes, file sizes, and MAY also include other useful information about images, such as the types of hardware a particular image is compatible with.
+The Targets metadata on a repository contains all of the information about images to be installed on ECUs. This includes filenames, hashes, file sizes, and MAY also include other useful information about images, such as what types of hardware are compatible with a particular image.
 
 Targets metadata can also contain metadata about delegations, allowing one Targets role to delegate its authority to another. This means that an individual Targets metadata file might contain only metadata about delegations, only metadata about images, or some combination of the two. The details of how ECUs traverse the delegation tree to find valid metadata about images is specified in {{resolve_delegations}}.
 
-#### Metadata about Images {#targets_images_meta}
+#### Metadata about images {#targets_images_meta}
 
-To be available to install on clients, all images on the repository MUST have their metadata listed in a targets role.  Each targets role MAY provide a list of some images on the repository.  This list MUST provide, at a minimum, the following information about each image:
+To be available to install on clients, all images on the repository MUST have their metadata listed in a Targets role.  Each Targets role MAY provide a list of some images on the repository.  This list MUST provide, at a minimum, the following information about each image:
 
 * The image filename
 * The size of the image in bytes
@@ -476,13 +486,13 @@ To be available to install on clients, all images on the repository MUST have th
 
 ##### Custom metadata about images
 
-In addition to the required metadata, Targets metadata files MAY contain extra metadata for images on the repository. This metadata can be customized for a particular use case. Examples of use cases for different types of custom metadata can be found in the Deployment Considerations document. However, there are a few important pieces of custom metadata that SHOULD be present in most implementations. In addition, there is one element in the custom metadata that MUST be present in the targets metadata from the director.
+In addition to the required metadata, Targets metadata files MAY contain extra metadata for images on the repository. This metadata can be customized for a particular use case. Examples of use cases for different types of custom metadata can be found in the Deployment Considerations document. However, there are a few important pieces of custom metadata that SHOULD be present in most implementations. In addition, there is one element in the custom metadata that MUST be present in the Targets metadata from the Director.
 
-Custom metadata also MAY contain a field or section that is demarcated as custom metadata that MUST match whenever two pieces of metadata are checked against each other--most commonly, when targets metadata from the Director and Image repositories are checked against each other.
+Custom metadata also MAY contain a field or section that is demarcated as custom metadata, and this field MUST match whenever two pieces of metadata are checked against each other. Most commonly, this occurs when targets metadata from the Director and Image repositories are checked against each other.
 
-The following information SHOULD be provided for each image on both the Image repository and the Director repository, and SHOULD be included in the "MUST match" section, if it is implemented:
+The following information SHOULD be provided for each image on both the Image repository and the Director repository and, if implemented, SHOULD be included in the "MUST match" section:
 
-* A release counter, to be incremented each time a new version of the image is released. This can be used to prevent rollback attacks even in cases where the director repository is compromised.
+* A release counter, to be incremented each time a new version of the image is released. This can be used to prevent rollback attacks even in cases where the Director repository is compromised.
 * A hardware identifier, or list of hardware identifiers, representing models of ECUs with which the image is compatible. This can be used to ensure that an ECU cannot be ordered to install an incompatible image, even in cases where the Director repository is compromised.
 
 The following information is CONDITIONALLY REQUIRED for each image on the Director repository IF that image is encrypted:
@@ -490,15 +500,15 @@ The following information is CONDITIONALLY REQUIRED for each image on the Direct
 * Information about filenames, hashes, and file size of the encrypted image.
 * Information about the encryption method, and other relevant information--for example, a symmetric encryption key encrypted by the ECU's asymmetric key could be included in the Director repository metadata.
 
-The following information MUST be provided for each image in the targets metadata from the Director repository:
+The following information MUST be provided for each image in the Targets metadata from the Director repository:
 
 * An ECU identifier (such as a serial number), specifying the ECU that should install the image.
 
 The Director repository MAY provide a download URL for the image file. This may be useful, for example, when the image is on a public CDN and the director wishes to provide a signed URL.
 
-#### Metadata about Delegations {#delegations_meta}
+#### Metadata about delegations {#delegations_meta}
 
-A Targets metadata file on the Image repository (but not the Director repository) MAY delegate signing authority to other entities--for example, it could delegate signing authority for a particular ECU's firmware to that ECU's supplier. A metadata file MAY contain more than one delegation and MUST keep the delegations in prioritized order.
+A Targets metadata file on the Image repository (but not the Director repository) MAY delegate signing authority to other entities. For example, it could delegate signing authority for a particular ECU's firmware to that ECU's supplier. A metadata file MAY contain more than one delegation and MUST keep the delegations in prioritized order.
 
 A list of delegations MUST provide the following information:
 
@@ -512,9 +522,9 @@ A list of delegations MUST provide the following information:
     * The key identifiers for each key this role uses
     * A threshold of keys that must sign for this role
 
-Note that **any** targets metadata file stored on the Image repository may contain delegations, and these delegations can be in chains of arbitrary length.
+Note that **any** Targets metadata file stored on the Image repository may contain delegations, and these delegations can be in chains of arbitrary length.
 
-### Snapshot Metadata {#snapshot_meta}
+### Snapshot metadata {#snapshot_meta}
 
 The Snapshot metadata lists version numbers and filenames of all Targets metadata files. It protects against mix-and-match attacks if a delegated supplier key is compromised.
 
@@ -522,27 +532,27 @@ For each Targets metadata file on the repository, the Snapshot metadata SHALL co
 
 * The filename and version number of the each Targets metadata file on the repository
 
-The Snapshot metadata MAY also list the root metadata filename and version number. This is not required, particularly for implementations of {{TAP-5}}, but MAY be included in all cases for backward compatibility.
+The Snapshot metadata MAY also list the Root metadata filename and version number. This is not required, particularly for implementations of {{TAP-5}}, but MAY be included in all cases for backward compatibility.
 
-### Timestamp Metadata {#timestamp_meta}
+### Timestamp metadata {#timestamp_meta}
 
 The Timestamp metadata SHALL contain the following information:
 
-* The filename and version number of the latest snapshot metadata on the repository.
-* One or more hashes of the snapshot metadata file, along with the hashing function used.
+* The filename and version number of the latest Snapshot metadata on the repository.
+* One or more hashes of the Snapshot metadata file, along with the hashing function used.
 
 ### Repository mapping metadata {#repo_mapping_meta}
 
 As described in the introduction to {{design}}, Uptane requires a Director repository and an Image repository. However, it is possible to have an Uptane-compliant implementation that has more than two repositories.
 
-Repository mapping metadata informs a primary ECU about which repositories to trust for images or image paths. {{TAP-4}} describes how to make use of more complex repository mapping metadata, to have more than the two required repositories.
+Repository mapping metadata informs a Primary ECU about which repositories to trust for images or image paths. {{TAP-4}} describes how to make use of more complex repository mapping metadata in order to have more than the two required repositories.
 
-Repository mapping metadata, or the equivalent informational content, MUST be present on all primary ECUs, and MUST contain the following information:
+Repository mapping metadata, or the equivalent informational content, MUST be present on all Primary ECUs, and MUST contain the following information:
 
 * A list of repository names and one or more URLs at which the named repository can be accessed. At a minimum, this MUST include the Director and Image repositories.
 * A list of mappings of image paths to repositories, each of which contains:
     * A list of image paths. Image paths MAY be expressed using wildcards, or by enumerating a list, or a combination of the two.
-    * A list of repositories that MUST sign the targets metadata for the image paths.
+    * A list of repositories that MUST sign the Targets metadata for the image paths.
 
 For example, in the most basic Uptane case, the repository mapping metadata would contain:
 
@@ -550,7 +560,7 @@ For example, in the most basic Uptane case, the repository mapping metadata woul
 * The name and URL of the Image repository
 * A single mapping indicating that all images (`*`) MUST be signed by both the Director and Image repository
 
-Note that the metadata need not be in the form of a metadata file. For example, in the basic case where there is only one director and one image repository, and all images need to have signed metadata from both repositories, it would be sufficient to have a configuration file with URLs for the two repositories, and a client that always checks for metadata matches between the two repositories. In this case, there would be no place with an explicit mapping defined, because the mapping would be defined as part of the Uptane client implementation.
+Note that the metadata need not be in the form of a metadata file. For example, in the basic case where there is only one Director and one Image repository, and all images need to have signed metadata from both repositories, it would be sufficient to have a configuration file with URLs for the two repositories, and a client that always checks for metadata matches between them. In this case, no explicit mapping would be defined, because the mapping is defined as part of the Uptane client implementation.
 
 The *Deployment Considerations* document ({{DEPLOY}}) gives more guidance on how to implement repository mapping metadata for more complex use cases. It also discusses strategies for updating repository mapping metadata, if required.
 
@@ -561,12 +571,12 @@ There is a difference between the file name in a metadata file or an ECU, and th
 Unless stated otherwise, all files SHALL be written to repositories in accordance with the following two rules:
 
 1. Metadata filenames SHALL be qualified with version numbers. If a metadata file A is specified as FILENAME.EXT in another metadata file B, then it SHALL be written as VERSION.FILENAME.EXT, where VERSION is A's version number, as defined in {{common_metadata}}, with one exception: If the version number of the Timestamp metadata file might not be known in advance by a client, it MAY be read from, and written to, a repository using a filename without a version number qualification, i.e. FILENAME.EXT.
-2. If an image is specified in a targets metadata file as FILENAME.EXT, it SHALL be written to the repository as HASH.FILENAME.EXT, where HASH is one of the hash digests of the file, as specified in {{targets_images_meta}}. The file MUST be written to the repository using *n* different filenames, one for each hash digest listed in its corresponding targets metadata.
+2. If an image is specified in a Targets metadata file as FILENAME.EXT, it SHALL be written to the repository as HASH.FILENAME.EXT, where HASH is one of the hash digests of the file, as specified in {{targets_images_meta}}. The file MUST be written to the repository using *n* different filenames, one for each hash digest listed in its corresponding Targets metadata.
 
 For example:
 
-* The version number of the Snapshot metadata file is 61, and its filename in the Timestamp metadata is "snapshot.json". The filename on the repository will be "61.snapshot.json".
-* There is an image with the filename "acme_firmware.bin" specified in the Targets metadata, with a SHA256 of "aaaa" and a SHA512-256 of "bbbb". It will have two filenames on the repository: "aaaa.acme_firmware.bin" and "bbbb.acme_firmware.bin".
+* The version number of the Snapshot metadata file is 61, and its filename in the Timestamp metadata is "snapshot.json." The filename on the repository will be "61.snapshot.json."
+* There is an image with the filename "acme_firmware.bin" specified in the Targets metadata, with a SHA256 of "aaaa" and a SHA512-256 of "bbbb." It will have two filenames on the repository: "aaaa.acme_firmware.bin" and "bbbb.acme_firmware.bin."
 
 ## Server / repository implementation requirements
 
@@ -577,7 +587,7 @@ An Uptane implementation SHALL make the following services available to vehicles
 
 Additionally, an Uptane implementation requires ECUs to have a secure way to know the current time.
 
-### Image Repository
+### Image repository
 
 The Image repository exists to allow an OEM and/or its suppliers to upload images and their associated metadata. It makes these images and their metadata available to vehicles. The Image repository is designed to be primarily controlled by human actors, and updated relatively infrequently.
 
@@ -591,7 +601,7 @@ The Image repository SHALL implement storage which permits authorized users to w
 
 The Image repository MAY require authentication for read access.
 
-### Director Repository {#director_repository}
+### Director repository {#director_repository}
 
 The Director repository instructs ECUs as to which images should be installed by producing signed metadata on demand. Unlike the Image repository, it is mostly controlled by automated, online processes. It also consults a private inventory database containing information on vehicles, ECUs, and software revisions.
 
@@ -604,15 +614,15 @@ The Director repository SHALL implement storage which permits an automated servi
 
 A Director repository MUST conform to the following six-step process for directing the installation of software images on a vehicle.
 
-1. The Director SHOULD first identify the vehicle. This MAY be done when the Director receives a vehicle version manifest sent by a primary (as described in {{construct_manifest_primary}}), decodes the manifest, and determines the unique vehicle identifier. Additionally, the Director MAY utilize other mechanisms to uniquely identify a vehicle (e.g., 2-way TLS with unique client certificates).
+1. The Director SHOULD first identify the vehicle. This MAY be done when the Director receives a vehicle version manifest sent by a Primary (as described in {{construct_manifest_primary}}), decodes the manifest, and determines the unique vehicle identifier. Additionally, the Director MAY utilize other mechanisms to uniquely identify a vehicle (e.g., 2-way TLS with unique client certificates).
 1. Using the vehicle identifier, the Director queries its inventory database (as described in {{inventory_db}}) for relevant information about each ECU in the vehicle.
-1. The Director SHALL check the manifest for accuracy compared to the information in the inventory database. If any of the required checks fail, the Director MAY drop the request. An implementer MAY make whatever additional checks they wish. At a minimum, the Director SHALL check the following:
+1. The Director SHALL check the manifest for accuracy compared to the information in the inventory database. If any of the required checks fail, the Director MAY drop the request. An implementer MAY make additional checks if desired. At a minimum, the Director SHALL check the following:
     * Each ECU recorded in the inventory database is also represented in the manifest.
-    * The signature of the manifest matches the ECU key of the primary that sent it.
-    * The signature of each secondary's contribution to the manifest matches the ECU key of that secondary.
+    * The signature of the manifest matches the ECU key of the Primary that sent it.
+    * The signature of each Secondary's contribution to the manifest matches the ECU key of that Secondary.
 1. The Director extracts information about currently installed images from the vehicle version manifest. Using this information, it determines if the vehicle is already up-to-date, and if not, determines a set of images that should be installed. The exact process by which this determination takes place is out of scope of this standard. However, the Director MUST take into account *dependencies* and *conflicts* between images and SHOULD consult well-established techniques for dependency resolution.
 1. The Director MAY encrypt images for ECUs that require it.
-1. The Director generates new metadata representing the desired set of images to be installed on the vehicle, based on the dependency resolution in step 4. This includes targets ({{targets_meta}}), snapshot ({{snapshot_meta}}), and timestamp ({{timestamp_meta}}) metadata. It then sends this metadata to the primary as described in {{download_meta_primary}}.
+1. The Director generates new metadata representing the desired set of images to be installed on the vehicle, based on the dependency resolution in step 4. This includes Targets ({{targets_meta}}), Snapshot ({{snapshot_meta}}), and Timestamp ({{timestamp_meta}}) metadata. It then sends this metadata to the Primary as described in {{download_meta_primary}}.
 
 #### Inventory Database {#inventory_db}
 
@@ -627,17 +637,17 @@ The inventory database MUST record the following pieces of information:
     * The vehicle identifier the ECU is associated with
     * An ECU key (symmetric or asymmetric; for asymmetric keys, only the public part SHOULD be stored)
     * The ECU key identifier (as defined in {{common_metadata}})
-    * Whether the ECU is a primary or a secondary
+    * A notation of whether the ECU is a Primary or a Secondary
 
-The inventory database MAY record other information about ECUs and vehicles. It SHOULD record a hardware identifier for each ECU, to protect against the possibility of directing the ECU to install an incompatible firmware.
+The inventory database MAY record other information about ECUs and vehicles. It SHOULD record a hardware identifier for each ECU to protect against the possibility of directing the ECU to install incompatible firmware.
 
 ## In-vehicle implementation requirements
 
-An Uptane-compliant ECU SHALL be able to download and verify image metadata and image binaries before installing a new image and MUST have a secure way of verifying the current time, or a sufficiently recent attestation of the time.
+An Uptane-compliant ECU SHALL be able to download and verify Image metadata and image binaries before installing a new image and MUST have a secure way of verifying the current time, or a sufficiently recent attestation of the time.
 
-Each ECU in a vehicle receiving over-the-air updates is either a primary or a secondary ECU. A primary ECU collects and delivers to the Director vehicle manifests ({{vehicle_version_manifest}}) containing information about which images have been installed on ECUs in the vehicle. It also verifies the time and downloads and verifies the latest metadata and images for itself and for its secondaries. A secondary ECU verifies the time and downloads and verifies the latest metadata and images for itself from its associated primary ECU. It also sends signed information about its installed images to its associated primary.
+Each ECU in a vehicle receiving over-the-air updates is either a Primary or a Secondary ECU. A Primary ECU collects and delivers vehicle manifests to the Director ({{vehicle_version_manifest}}) that contain information about which images have been installed on ECUs in the vehicle. It also verifies the time and downloads and verifies the latest metadata and images for itself and for its secondaries. A Secondary ECU verifies the time, and downloads and verifies the latest metadata and images for itself from its associated Primary ECU. It also sends signed information about its installed images to its associated Primary.
 
-All ECUs MUST verify image metadata as specified in {{metadata_verification}} before installing an image or making it available to other ECUs. A primary ECU MUST perform full verification ({{full_verification}}). A secondary ECU SHOULD perform full verification if possible. If a secondary cannot perform full verification, it SHALL perform partial verification. See [Uptane Deployment Considerations](#DEPLOY) for a discussion of how to choose between partial and full verification.
+All ECUs MUST verify image metadata as specified in {{metadata_verification}} before installing an image or making it available to other ECUs. A Primary ECU MUST perform full verification ({{full_verification}}). A Secondary ECU SHOULD perform full verification if possible. If a Secondary cannot perform full verification, it SHALL perform partial verification. See [Uptane Deployment Considerations](#DEPLOY) for a discussion of how to choose between partial and full verification.
 
 ECUs MUST have a secure source of time. An OEM/Uptane implementor MAY use any external source of time that is demonstrably secure. The Uptane deployment considerations ({{DEPLOY}}) describe one way to implement an external time server to cryptographically attest time, as well as the security properties required. When "loading time" is referenced in procedures in this standard, it should be understood to mean loading into memory the current time (if the ECU has its own secure clock), or the most recent attested time.
 
@@ -647,33 +657,33 @@ For an ECU to be capable of receiving Uptane-secured updates, it MUST have the f
 
 1. A sufficiently recent copy of required Uptane metadata at the time of manufacture or install. See [Uptane Deployment Considerations](#DEPLOY) for more information.
     * Partial verification ECUs MUST have the Root and Targets metadata from the Director repository.
-    * Full verification ECUs MUST have a complete set of metadata (root, targets, snapshot, and timestamp) from both repositories, as well as the repository mapping metadata ({{repo_mapping_meta}}).
+    * Full verification ECUs MUST have a complete set of metadata (Root, Targets, Snapshot, and Timestamp) from both repositories, as well as the repository mapping metadata ({{repo_mapping_meta}}).
 2. The current time, or a secure attestation of a sufficiently recent time.
 3. An **ECU key**. This is a private key, unique to the ECU, used to sign ECU version manifests and decrypt images. An ECU key MAY be either a symmetric key or an asymmetric key. If it is an asymmetric key, there MAY be separate keys for encryption and signing. For the purposes of this standard, the set of private keys that an ECU uses is referred to as the ECU key (singular), even if it is actually multiple keys used for different purposes.
 
-### What the primary does
+### What the Primary does
 
-A primary downloads, verifies, and distributes the latest time, metadata and images. To do so, it SHALL perform the following seven steps:
+A Primary downloads, verifies, and distributes the latest time, metadata and images. To do so, it SHALL perform the following seven steps:
 
 1. Construct and send vehicle version manifest ({{construct_manifest_primary}})
 1. Download and check current time ({{check_time_primary}})
 1. Download and verify metadata ({{download_meta_primary}})
 1. Download and verify images ({{download_images_primary}})
 1. OPTIONAL: Send latest time to secondaries ({{send_time_primary}})
-1. Send metadata to secondaries ({{send_metadata_primary}})
-1. Send images to secondaries ({{send_images_primary}})
+1. Send metadata to Secondaries ({{send_metadata_primary}})
+1. Send images to Secondaries ({{send_images_primary}})
 
 
-Note that the subsequent sections concerning requirements for a primary do not prohibit implementing primary capabilities on an ECU which does not communicate directly with the Uptane repositories. This allows for implementations to have multiple ECUs within the vehicle performing functions equivalent to a primary.
-If multiple such primaries are included within a vehicle, each secondary ECU SHALL have a single primary responsible for providing its updates.
+Note that the subsequent sections concerning requirements for a Primary do not prohibit implementing Primary capabilities on an ECU that does not communicate directly with the Uptane repositories. This allows for implementations to have multiple ECUs within the vehicle performing functions equivalent to a Primary.
+If multiple such Primaries are included within a vehicle, each Secondary ECU SHALL have a single Primary responsible for providing its updates.
 
 #### Construct and send vehicle version manifest {#construct_manifest_primary}
 
-The primary SHALL build a *vehicle version manifest* as described in {{vehicle_version_manifest}}.
+The Primary SHALL build a *vehicle version manifest* as described in {{vehicle_version_manifest}}.
 
-Once it has the complete manifest built, it MAY send the manifest to the Director repository. However, it is not strictly required that the primary send the manifest until step three. If permitted by the implementation, a primary MAY send only a diff of the manifest, to save bandwidth. If an implementation permits diffs, the Director SHOULD have a way to request a full manifest.
+Once the complete manifest is built, the Primary MAY send the manifest to the Director repository. However, it is not strictly required that the Primary send the manifest until step three. If permitted by the implementation, a Primary MAY send only a diff of the manifest to save bandwidth. If an implementation permits diffs, the Director SHOULD have a way to request a full manifest.
 
-Secondaries MAY send their version report at any time so that it is already stored on the primary when it wishes to check for updates. Alternatively, the primary MAY request a version report from each secondary at the time of the update check.
+Secondaries MAY send their version report at any time so that it is already stored on the Primary when it wishes to check for updates. Alternatively, the Primary MAY request a version report from each Secondary at the time of the update check.
 
 ##### Vehicle version manifest {#vehicle_version_manifest}
 
@@ -687,10 +697,10 @@ The vehicle version manifest is a metadata structure that MUST contain the follo
   * The signature of the hash
 * A payload representing the installed versions of each software image on the vehicle. This payload SHALL contain:
   * The vehicle's unique identifier (e.g. the VIN)
-  * The primary ECU's unique identifier (e.g. the serial number)
+  * The Primary ECU's unique identifier (e.g. the serial number)
   * A list of ECU version reports as specified in {{version_report}}
 
-Note that one of the ECU version reports should be the version report for the primary itself.
+Note that one of the ECU version reports should be the version report for the Primary itself.
 
 ##### ECU version report {#version_report}
 
@@ -711,37 +721,37 @@ An ECU version report is a metadata structure that MUST contain the following in
 
 #### Download and check current time {#check_time_primary}
 
-The primary SHALL load the current time from a secure source.
+The Primary SHALL load the current time from a secure source.
 
 #### Download and verify metadata {#download_meta_primary}
 
-The primary SHALL download metadata for all targets and perform a full verification on it as specified in {{full_verification}}.
+The Primary SHALL download metadata for all targets and perform a full verification on it as specified in {{full_verification}}.
 
 #### Download and verify images {#download_images_primary}
 
-The primary SHALL download and verify images for itself and for all of its associated secondaries. Images SHALL be verified by checking that the hash of the image file matches the hash specified in the director's targets metadata for that image.
+The Primary SHALL download and verify images for itself and for all of its associated Secondaries. Images SHALL be verified by checking that the hash of the image file matches the hash specified in the Director's Targets metadata for that image.
 
-There may be several different filenames that all refer to the same image binary, as described in {{targets_meta}}. The primary SHALL associate each image binary with each of its possible filenames.
+There may be several different filenames that all refer to the same image binary, as described in {{targets_meta}}. The Primary SHALL associate each image binary with each of its possible filenames.
 
-#### Send latest time to secondaries {#send_time_primary}
+#### Send latest time to Secondaries {#send_time_primary}
 
-Unless the secondary ECU has its own way of verifying the time or does not have the capacity to verify a time message, the primary is CONDITIONALLY REQUIRED to send the time to each ECU. The secondary will verify the time message, then overwrite its current time with the received time.
+Unless the Secondary ECU has its own way of verifying the time or does not have the capacity to verify a time message, the Primary is CONDITIONALLY REQUIRED to send the time to each ECU. The Secondary will verify the time message, then overwrite its current time with the received time.
 
-#### Send metadata to secondaries {#send_metadata_primary}
+#### Send metadata to Secondaries {#send_metadata_primary}
 
-The primary SHALL send its latest downloaded metadata to all of its associated secondaries. The metadata it sends to each secondary MUST include all of the metadata required for verification on that secondary. For full verification secondaries, this includes the metadata for all four roles from both repositories, plus any delegated targets metadata files the secondary will recurse through to find the proper delegation. For partial verification secondaries, this includes only the targets metadata file from the director repository.
+The Primary SHALL send its latest downloaded metadata to all of its associated Secondaries. The metadata it sends to each Secondary MUST include all of the metadata required for verification on that Secondary. For full verification Secondaries, this includes the metadata for all four roles from both repositories, plus any delegated Targets metadata files the Secondary will recurse through to find the proper delegation. For partial verification Secondaries, this includes only the Targets metadata file from the Director repository.
 
-The primary SHOULD determine the minimal set of metadata files to send to each secondary, by performing delegation resolution as described in {{full_verification}}.
+The Primary SHOULD determine the minimal set of metadata files to send to each Secondary by performing delegation resolution as described in {{full_verification}}.
 
-Each secondary SHALL store the latest copy of all metadata required for its own verification.
+Each Secondary SHALL store the latest copy of all metadata required for its own verification.
 
-#### Send images to secondaries {#send_images_primary}
+#### Send images to Secondaries {#send_images_primary}
 
-The primary SHALL send the latest image to each of its associated secondaries that have storage to receive it.
+The Primary SHALL send the latest image to each of its associated Secondaries that have storage to receive it.
 
-For secondaries without storage, the primary SHOULD wait for a request from the secondary to stream the new image file to it. The secondary will send the request once it has verified the metadata sent in the previous step.
+For Secondaries without storage, the Primary SHOULD wait for a request from the Secondary to stream the new image file to it. The Secondary will send the request once it has verified the metadata sent in the previous step.
 
-### Installing images on primary or secondary ECUs
+### Installing images on Primary or Secondary ECUs
 
 An ECU SHALL perform the following steps when attempting to install a new image:
 
@@ -762,16 +772,16 @@ The ECU SHALL verify the latest downloaded metadata ({{metadata_verification}}) 
 
 #### Download latest image {#download_image}
 
-If the ECU does not have secondary storage, i.e. buffer storage to temporarily store the latest image before installing it, it SHALL download the latest image from the primary. (If the ECU has secondary storage, it will already have the latest image in its secondary storage as specified in {{send_images_primary}}, and should skip to the next step.) The ECU MAY first create a backup of its previous working image and store it elsewhere (e.g., the primary).
+If the ECU does not have secondary storage, i.e. buffer storage to temporarily store the latest image before installing it, it SHALL download the latest image from the Primary. (If the ECU has secondary storage, it will already have the latest image in its secondary storage as specified in {{send_images_primary}}, and should skip to the next step.) The ECU MAY first create a backup of its previous working image and store it elsewhere (e.g., the primary).
 
-The filename used to identify the latest known image (i.e., the file to request from the primary) SHALL be determined as follows:
+The filename used to identify the latest known image (i.e., the file to request from the Primary) SHALL be determined as follows:
 
 1. Load the Targets metadata file from the Director repository.
 2. Find the Targets metadata associated with this ECU identifier.
 3. Construct the Image filename using the rule in {{metadata_filename_rules}}, or use the download URL specified in the Director metadata.
 4. If there is no Targets metadata about this image, abort the update cycle and report that there is no such image. Additionally, in the case of failure, the ECU SHALL retain its previous Targets metadata instead of using the new Targets metadata. Otherwise, download the image (up to the number of bytes specified in the Targets metadata), and verify that its hashes match the Targets metadata.
 
-When the primary responds to the download request, the ECU SHALL overwrite its current image with the downloaded image from the primary.
+When the Primary responds to the download request, the ECU SHALL overwrite its current image with the downloaded image from the Primary.
 
 If any part of this step fails, the ECU SHALL jump to the fifth step ({{create_version_report}}).
 
@@ -779,35 +789,35 @@ If any part of this step fails, the ECU SHALL jump to the fifth step ({{create_v
 
 The ECU SHALL verify that the latest image matches the latest metadata as follows:
 
-1. Load the latest Targets metadata file from the director.
+1. Load the latest Targets metadata file from the Director.
 2. Find the Targets metadata associated with this ECU identifier.
 3. Check that the hardware identifier in the metadata matches the ECUs hardware identifier.
-4. Check that the image filename is valid for this ECU. This MAY be a comparison against a wildcard path and restricts the ECUs a delegation applies to.
+4. Check that the image filename is valid for this ECU. This MAY be a comparison against a wildcard path, which restricts the ECUs to which a delegation will apply.
 5. Check that the release counter of the image in the previous metadata, if it exists, is less than or equal to the release counter in the latest metadata.
 6. If the image is encrypted, decrypt the image with a decryption key to be chosen as follows:
     * If the ECU key is a symmetric key, the ECU SHALL use the ECU key for image decryption.
-    * If the ECU key is asymmetric, the ECU SHALL check the target metadata for an encrypted symmetric key. If such a key is found, the ECU SHALL decrypt the symmetric key using its ECU key, and use the decrypted symmetric key for image decryption.
+    * If the ECU key is asymmetric, the ECU SHALL check the Targets metadata for an encrypted symmetric key. If such a key is found, the ECU SHALL decrypt the symmetric key using its ECU key, and use the decrypted symmetric key for image decryption.
     * If the ECU key is asymmetric and there is no symmetric key in the target metadata, the ECU SHALL use its ECU key for image decryption.
 7. Check that the hash of the image matches the hash in the metadata.
 
-If the ECU has secondary storage, the checks SHOULD be performed on the image in secondary storage, before it is installed.
+If the ECU has secondary storage, the checks SHOULD be performed on the image in secondary storage before it is installed.
 
-NOTE: See {{DEPLOY}} for guidance on how to deal with secondary ECU failures for ECUs that do not have secondary storage.
+NOTE: See {{DEPLOY}} for guidance on how to deal with Secondary ECU failures for ECUs that do not have secondary storage.
 
 If any step fails, the ECU SHALL jump to the ({{create_version_report}}) step.  
 
 
 #### Install image {#install_image}
 
-The ECU SHALL attempt to install the update. This installation SHOULD occur at a time when all pre-conditions are met. These pre-conditions MAY include ensuring the vehicle is in a safe environment for install (e.g., the vehicle is in a parked state when updating a specific ECU). Another pre-condition MAY include ensuring the ECU has a backup of its current image and metadata in case the current installation fails.
+The ECU SHALL attempt to install the update. This installation SHOULD occur at a time when all pre-conditions are met. These pre-conditions MAY include ensuring the vehicle is in a safe environment for install (e.g., the vehicle is parked when updating a specific ECU). Another pre-condition MAY include ensuring the ECU has a backup of its current image and metadata in case the current installation fails.
 
 #### Create and send version report {#create_version_report}
 
-The ECU SHALL create a version report as described in {{version_report}}, and send it to the primary (or simply save it to disk, if the ECU is a primary). The primary SHOULD write the version reports it receives to disk and associate them with the secondaries that sent them.
+The ECU SHALL create a version report as described in {{version_report}}, and send it to the Primary (or simply save it to disk, if the ECU is a Primary). The Primary SHOULD write the version reports it receives to disk and associate them with the Secondaries that sent them.
 
 ### Metadata verification procedures {#metadata_verification}
 
-A primary ECU MUST perform full verification of metadata. A secondary ECU SHOULD perform full verification of metadata. If a secondary cannot perform full verification it SHALL perform partial verification instead.
+A Primary ECU MUST perform full verification of metadata. A Secondary ECU SHOULD perform full verification of metadata. If a Secondary cannot perform full verification, it SHALL perform partial verification instead.
 
 If a step in the following workflows does not succeed (e.g., the update is aborted because a new metadata file was not signed), an ECU SHOULD still be able to update again in the future. Errors raised during the update process SHOULD NOT leave ECUs in an unrecoverable state.
 
@@ -822,11 +832,11 @@ In order to perform partial verification, an ECU SHALL perform the following ste
 
 Full verification of metadata means that the ECU checks that the Targets metadata about images from the Director repository matches the Targets metadata about the same images from the Image repository. This provides resilience to a key compromise in the system.
 
-Full verification MAY be performed by either primary or secondary ECUs. In the following instructions, whenever an ECU is directed to download metadata, it applies only to primary ECUs.
+Full verification MAY be performed by either Primary or Secondary ECUs. In the following instructions, whenever an ECU is directed to download metadata, it applies only to Primary ECUs.
 
-If {{TAP-5}} is supported and a primary has an external connection to the Uptane repositories, a primary ECU SHALL download metadata and images following the rules specified in that TAP.  If {{TAP-5}} is not supported or if the primary does not have an external connection to the Uptane repositories, the download SHOULD follow the {{TUF-spec}} and the metadata file renaming rules specified in {{metadata_filename_rules}}.
+If {{TAP-5}} is supported and a Primary has an external connection to the Uptane repositories, a Primary ECU SHALL download metadata and images following the rules specified in that TAP.  If {{TAP-5}} is not supported, or if the Primary does not have an external connection to the Uptane repositories, the download SHOULD follow the {{TUF-spec}} and the metadata file renaming rules specified in {{metadata_filename_rules}}.
 
-Before starting full verification, the repository mapping metadata MUST be consulted to determine where to download metadata from. This procedure assumes the basic Uptane case: there are only two repositories (Director and Image), and all image paths are required to be signed by both repositories. If a more complex repository layout is being used, refer to {{DEPLOY}} for guidance on how to determine where to download metadata from.
+Before starting full verification, it must be determined from where metadata should be downloaded. For this task, the repository mapping metadata MUST be consulted. This procedure assumes the basic Uptane case: there are only two repositories (Director and Image), and all image paths are required to be signed by both repositories. If a more complex repository layout is being used, refer to {{DEPLOY}} for guidance on how to determine where metadata should be downloaded from.
 
 In order to perform full verification, an ECU SHALL perform the following steps:
 
@@ -839,26 +849,26 @@ In order to perform full verification, an ECU SHALL perform the following steps:
 1. Download and check the Timestamp metadata file from the Image repository, following the procedure in {{check_timestamp}}.
 1. Download and check the Snapshot metadata file from the Image repository, following the procedure in {{check_snapshot}}.
 1. Download and check the top-level Targets metadata file from the Image repository, following the procedure in {{check_targets}}.
-1. Verify that Targets metadata from the Director and Image repositories match. A primary ECU MUST perform this check on metadata for all images listed in the Targets metadata file from the Director repository downloaded in step 6. A secondary ECU MAY elect to perform this check only on the metadata for the image it will install. (That is, the target metadata from the Director that contains the ECU identifier of the current ECU.) To check that the metadata for an image matches, complete the following procedure:
+1. Verify that Targets metadata from the Director and Image repositories match. A Primary ECU MUST perform this check on metadata for all images listed in the Targets metadata file from the Director repository downloaded in step 6. A Secondary ECU MAY elect to perform this check only on the metadata for the image it will install. (That is, the Targets metadata from the Director that contains the ECU identifier of the current ECU.) To check that the metadata for an image matches, complete the following procedure:
     1. Locate and download a Targets metadata file from the Image repository that contains an image with exactly the same file name listed in the Director metadata, following the procedure in {{resolve_delegations}}.
     2. Check that the Targets metadata from the Image repository matches the Targets metadata from the Director repository:
-        1. Check that the non-custom metadata (i.e., length and hashes) of the unencrypted or encrypted image are the same in both sets of metadata. Note: the primary is responsible for validating encrypted images and associated metadata. The target ECU (primary or secondary) is responsible for validating the unencrypted image and associated metadata.
+        1. Check that the non-custom metadata (i.e., length and hashes) of the unencrypted or encrypted image are the same in both sets of metadata. Note: the Primary is responsible for validating encrypted images and associated metadata. The target ECU (Primary or Secondary) is responsible for validating the unencrypted image and associated metadata.
         2. Check that all "MUST match" custom metadata (e.g., hardware identifier and release counter) are the same in both sets of metadata.
-        3. Check that the release counter in the previous targets metadata file is less than or equal to the release counter in this targets metadata file.
+        3. Check that the release counter in the previous Targets metadata file is less than or equal to the release counter in this Targets metadata file.
 
 If any step fails, the ECU MUST return an error code indicating the failure. If a check for a specific type of security attack fails (e.g. rollback, freeze, arbitrary software, etc.), the ECU SHOULD return an error code that indicates the type of attack.
 
-If the ECU performing the verification is the primary ECU, it SHOULD also ensure that the targets metadata from the director repository doesn't contain any ECU identifiers for ECUs not actually present in the vehicle.
+If the ECU performing the verification is the Primary ECU, it SHOULD also ensure that the Targets metadata from the Director repository doesn't contain any ECU identifiers for ECUs not actually present in the vehicle.
 
 #### How to check Root metadata {#check_root}
 
-To properly check root metadata, an ECU SHOULD:
+To properly check Root metadata, an ECU SHOULD:
 
 1. Load the previous Root metadata file.
 2. Update to the latest Root metadata file.
     1. Let N denote the version number of the latest Root metadata file (which at first could be the same as the previous root metadata file).
-    2. Try downloading a new version N+1 of the Root metadata file, up to some X number of bytes. The value for X is set by the implementor. For example, X may be tens of kilobytes. The filename used to download the root metadata file is of the fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is not available, the current Root metadata file is the latest; continue with step 3.
-    3. Version N+1 of the Root metadata file MUST have been signed by the following: (1) a threshold of keys specified in the latest Root metadata file (version N), and (2) a threshold of keys specified in the new Root metadata file being validated (version N+1). If version N+1 is not signed as required, discard it, abort the update cycle, and report the signature failure. On the next update cycle, begin at version N of the root metadata file. (Checks for an arbitrary software attack.)
+    2. Try downloading a new version N+1 of the Root metadata file, up to some X number of bytes. The value for X is set by the implementor. For example, X may be tens of kilobytes. The filename used to download the Root metadata file is of the fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is not available, the current Root metadata file is the latest; continue with step 3.
+    3. Version N+1 of the Root metadata file MUST have been signed by the following: (1) a threshold of keys specified in the latest Root metadata file (version N), and (2) a threshold of keys specified in the new Root metadata file being validated (version N+1). If version N+1 is not signed as required, discard it, abort the update cycle, and report the signature failure. On the next update cycle, begin at version N of the Root metadata file. (Checks for an arbitrary software attack.)
     4. The version number of the latest Root metadata file (version N) must be less than or equal to the version number of the new Root metadata file (version N+1). Effectively, this means checking that the version number signed in the new Root metadata file is indeed N+1. If the version of the new Root metadata file is less than the latest metadata file, discard it, abort the update cycle, and report the rollback attack. On the next update cycle, begin at step 0 and version N of the Root metadata file. (Checks for a rollback attack.)
     5. Set the latest Root metadata file to the new Root metadata file.
     6. Repeat steps 2.1 to 2.6.
@@ -867,17 +877,17 @@ To properly check root metadata, an ECU SHOULD:
 
 #### How to check Timestamp metadata {#check_timestamp}
 
-To properly check timestamp metadata, an ECU SHOULD:
+To properly check Timestamp metadata, an ECU SHOULD:
 
 1. Download up to Y number of bytes. The value for Y is set by the implementor. For example, Y may be tens of kilobytes. The filename used to download the Timestamp metadata file is of the fixed form FILENAME.EXT (e.g., timestamp.json).
-2. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. If the new timestamp metadata file is not properly signed, discard it, abort the update cycle, and report the signature failure. (Checks for an arbitrary software attack.)
+2. Check that it has been signed by the threshold of keys specified in the latest Root metadata file. If the new Timestamp metadata file is not properly signed, discard it, abort the update cycle, and report the signature failure. (Checks for an arbitrary software attack.)
 3. Check that the version number of the previous Timestamp metadata file, if any, is less than or equal to the version number of this Timestamp metadata file. If the new Timestamp metadata file is older than the trusted Timestamp metadata file, discard it, abort the update cycle, and report the potential rollback attack. (Checks for a rollback attack.)
 4. Check that the current (or latest securely attested) time is lower than the expiration timestamp in this Timestamp metadata file. If the new Timestamp metadata file has expired, discard it, abort the update cycle, and report the potential freeze attack. (Checks for a freeze attack.)
 
 
 #### How to check Snapshot metadata {#check_snapshot}
 
-To properly check snapshot metadata, an ECU SHOULD:
+To properly check Snapshot metadata, an ECU SHOULD:
 
 1. Download up to the number of bytes specified in the Timestamp metadata file, constructing the metadata filename as defined in {{metadata_filename_rules}}.
 2. The hashes and version number of the new Snapshot metadata file MUST match the hashes and version number listed in Timestamp metadata. If the hashes and version number do not match, discard the new Snapshot metadata, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.)
@@ -889,28 +899,28 @@ To properly check snapshot metadata, an ECU SHOULD:
 
 #### How to check Targets metadata {#check_targets}
 
-To properly check targets metadata, an ECU SHOULD:
+To properly check Targets metadata, an ECU SHOULD:
 
 1. Download up to Z number of bytes, constructing the metadata filename as defined in {{metadata_filename_rules}}. The value for Z is set by the implementor. For example, Z may be tens of kilobytes.
 1. The version number of the new Targets metadata file MUST match the version number listed in the latest Snapshot metadata. If the version number does not match, discard it, abort the update cycle, and report the failure. (Checks for a mix-and-match attack.) Skip this step if checking Targets metadata on a partial-verification ECU; partial-verification ECUs will not have Snapshot metadata.
 1. Check that the Targets metadata has been signed by the threshold of keys specified in the relevant metadata file (Checks for an arbitrary software attack):
-    1. If checking top-level targets metadata, the threshold of keys is specified in the Root metadata.
-    1. If checking delegated targets metadata, the threshold of keys is specified in the targets metadata file that delegated authority to this role.
+    1. If checking top-level Targets metadata, the threshold of keys is specified in the Root metadata.
+    1. If checking delegated Targets metadata, the threshold of keys is specified in the Targets metadata file that delegated authority to this role.
 1. Check that the version number of the previous Targets metadata file, if any, is less than or equal to the version number of this Targets metadata file. (Checks for a rollback attack.)
 1. Check that the current (or latest securely attested) time is lower than the expiration timestamp in this Targets metadata file. (Checks for a freeze attack.)
-1. If checking targets metadata from the Director repository, verify that there are no delegations.
-1. If checking targets metadata from the Director repository, check that no ECU identifier is represented more than once.
+1. If checking Targets metadata from the Director repository, verify that there are no delegations.
+1. If checking Targets metadata from the Director repository, check that no ECU identifier is represented more than once.
 
 #### How to resolve delegations {#resolve_delegations}
 
-To properly check targets metadata for an image, an ECU MUST locate the metadata file(s) for the role (or roles) that have the authority to sign the image. This metadata might be located in the top-level targets metadata, but it also may be delegated to another role--or to multiple roles. Therefore, all delegations MUST be resolved using the following recursive procedure, beginning with the top-level targets metadata file.
+To properly check Targets metadata for an image, an ECU MUST locate the metadata file(s) for the role (or roles) that have the authority to sign the image. This metadata might be located in the top-level Targets metadata, but it also may be delegated to another role or to multiple roles. Therefore, all delegations MUST be resolved using the following recursive procedure, beginning with the top-level Targets metadata file.
 
-1. Download the current metadata file, and check it following the procedure in {{check_targets}}. If the file cannot be loaded, or if any verification step fails, abort the delegation resolution, and indicate that image metadata cannot be found because of a missing or invalid role.
+1. Download the current metadata file, and check it following the procedure in {{check_targets}}. If the file cannot be loaded, or if any verification step fails, abort the delegation resolution, and indicate that Image metadata cannot be found because of a missing or invalid role.
 2. If the current metadata file contains signed metadata about the image, end the delegation resolution and return the metadata to be checked.
 3. If the current metadata file was reached via a terminating delegation and does not contain signed metadata about the image, abort the delegation resolution for this image and return an error indicating that image metadata could not be found.
 4. Search the list of delegations, in listed order. For each delegation:
     1. Check if the delegation applies to the image being processed. For the delegation to apply, it MUST include the hardware identifier of the target, and the target name must match one of the delegation's image paths. If either of these tests fail, move on to the next delegation in the list.
-    2. If the delegation is a multi-role delegation, follow the procedure described in {{multirole_delegations}}. If the multi-role delegation is terminating and no valid image metadata is found, abort the delegation resolution and return an error indicating that image metadata could not be found.
+    2. If the delegation is a multi-role delegation, follow the procedure described in {{multirole_delegations}}. If the multi-role delegation is terminating and no valid Image metadata is found, abort the delegation resolution and return an error indicating that image metadata could not be found.
     3. If the delegation is a normal delegation, perform delegation resolution, starting at step 1. Note that this may recurse an arbitrary number of levels deep. If a delegation that applies to the image is found but no image metadata is found in the delegated roles or any of its sub-delegations, simply continue on with the next delegation in the list. The search is only completed/aborted if image metadata or a terminating delegation that applies to the image is found.
 5. If the end of the list of delegations in the top-level metadata is reached without finding valid image metadata, return an error indicating that image metadata could not be found.
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -488,9 +488,9 @@ To be available to install on clients, all images on the repository MUST have th
 
 In addition to the required metadata, Targets metadata files MAY contain extra metadata for images on the repository. This metadata can be customized for a particular use case. Examples of use cases for different types of custom metadata can be found in the Deployment Considerations document. However, there are a few important pieces of custom metadata that SHOULD be present in most implementations. In addition, there is one element in the custom metadata that MUST be present in the Targets metadata from the Director.
 
-Custom metadata also MAY contain a field or section that is demarcated as custom metadata, and this field MUST match whenever two pieces of metadata are checked against each other. Most commonly, this occurs when targets metadata from the Director and Image repositories are checked against each other.
+Custom metadata MAY also contain a demarcated field or section that MUST match whenever two pieces of metadata are checked against each other, such as when Targets metadata from the Director repository is checked against Targets metadata from the Image repository. 
 
-The following information SHOULD be provided for each image on both the Image repository and the Director repository and, if implemented, SHOULD be included in the "MUST match" section:
+The information listed below SHOULD be provided for each image on both the Image repository and the Director repository. If a "MUST match section" is to be implemented, that is where this information SHOULD be placed.
 
 * A release counter, to be incremented each time a new version of the image is released. This can be used to prevent rollback attacks even in cases where the Director repository is compromised.
 * A hardware identifier, or list of hardware identifiers, representing models of ECUs with which the image is compatible. This can be used to ensure that an ECU cannot be ordered to install an incompatible image, even in cases where the Director repository is compromised.
@@ -575,8 +575,8 @@ Unless stated otherwise, all files SHALL be written to repositories in accordanc
 
 For example:
 
-* The version number of the Snapshot metadata file is 61, and its filename in the Timestamp metadata is "snapshot.json." The filename on the repository will be "61.snapshot.json."
-* There is an image with the filename "acme_firmware.bin" specified in the Targets metadata, with a SHA256 of "aaaa" and a SHA512-256 of "bbbb." It will have two filenames on the repository: "aaaa.acme_firmware.bin" and "bbbb.acme_firmware.bin."
+* The version number of the Snapshot metadata file is 61, and its filename in the Timestamp metadata is "snapshot.json". The filename on the repository will be "61.snapshot.json".
+* There is an image with the filename "acme_firmware.bin" specified in the Targets metadata, with a SHA256 of "aaaa" and a SHA512-256 of "bbbb". It will have two filenames on the repository: "aaaa.acme_firmware.bin" and "bbbb.acme_firmware.bin".
 
 ## Server / repository implementation requirements
 
@@ -637,7 +637,7 @@ The inventory database MUST record the following pieces of information:
     * The vehicle identifier the ECU is associated with
     * An ECU key (symmetric or asymmetric; for asymmetric keys, only the public part SHOULD be stored)
     * The ECU key identifier (as defined in {{common_metadata}})
-    * A notation of whether the ECU is a Primary or a Secondary
+    * Whether the ECU is a Primary or a Secondary
 
 The inventory database MAY record other information about ECUs and vehicles. It SHOULD record a hardware identifier for each ECU to protect against the possibility of directing the ECU to install incompatible firmware.
 
@@ -836,7 +836,7 @@ Full verification MAY be performed by either Primary or Secondary ECUs. In the f
 
 If {{TAP-5}} is supported and a Primary has an external connection to the Uptane repositories, a Primary ECU SHALL download metadata and images following the rules specified in that TAP.  If {{TAP-5}} is not supported, or if the Primary does not have an external connection to the Uptane repositories, the download SHOULD follow the {{TUF-spec}} and the metadata file renaming rules specified in {{metadata_filename_rules}}.
 
-Before starting full verification, it must be determined from where metadata should be downloaded. For this task, the repository mapping metadata MUST be consulted. This procedure assumes the basic Uptane case: there are only two repositories (Director and Image), and all image paths are required to be signed by both repositories. If a more complex repository layout is being used, refer to {{DEPLOY}} for guidance on how to determine where metadata should be downloaded from.
+Before starting full verification, the repository mapping metadata MUST be consulted to determine where to download metadata from. This procedure assumes the basic Uptane case: there are only two repositories (Director and Image), and all image paths are required to be signed by both repositories. If a more complex repository layout is being used, refer to {{DEPLOY}} for guidance on how to determine where metadata should be downloaded from.
 
 In order to perform full verification, an ECU SHALL perform the following steps:
 
@@ -849,7 +849,7 @@ In order to perform full verification, an ECU SHALL perform the following steps:
 1. Download and check the Timestamp metadata file from the Image repository, following the procedure in {{check_timestamp}}.
 1. Download and check the Snapshot metadata file from the Image repository, following the procedure in {{check_snapshot}}.
 1. Download and check the top-level Targets metadata file from the Image repository, following the procedure in {{check_targets}}.
-1. Verify that Targets metadata from the Director and Image repositories match. A Primary ECU MUST perform this check on metadata for all images listed in the Targets metadata file from the Director repository downloaded in step 6. A Secondary ECU MAY elect to perform this check only on the metadata for the image it will install. (That is, the Targets metadata from the Director that contains the ECU identifier of the current ECU.) To check that the metadata for an image matches, complete the following procedure:
+1. Verify that Targets metadata from the Director and Image repositories match. A Primary ECU MUST perform this check on metadata for all images listed in the Targets metadata file from the Director repository downloaded in step 6. A Secondary ECU MAY elect to perform this check only on the metadata for the image it will install. (That is, the target metadata from the Director that contains the ECU identifier of the current ECU.) To check that the metadata for an image matches, complete the following procedure:
     1. Locate and download a Targets metadata file from the Image repository that contains an image with exactly the same file name listed in the Director metadata, following the procedure in {{resolve_delegations}}.
     2. Check that the Targets metadata from the Image repository matches the Targets metadata from the Director repository:
         1. Check that the non-custom metadata (i.e., length and hashes) of the unencrypted or encrypted image are the same in both sets of metadata. Note: the Primary is responsible for validating encrypted images and associated metadata. The target ECU (Primary or Secondary) is responsible for validating the unencrypted image and associated metadata.


### PR DESCRIPTION
I've now gone through and have made sure  instances of proper names for roles, ECUs, and metadata are capitalized. I also fixed some inconsistent capitalization in headings and subheads. Now only the first word in headings is capitalized, except where proper nouns appear. This addresses  Issue #116.

I also addressed the one element in Issue #119. That is I've included the missing definition of "metadata." For this, I followed Ira's suggestion and included both the NIST definition and the version proposed by @mcvand in discussion on the issue.
I also added definitions for three acronyms used in the document that were never defined.
Lastly I fixed a handful of sentences that to my eye had structural.
I was going to add the citations to our definitions at the beginning of the document, per @iramcdonald. But I don't know how to set up the citations in Markdown using this particular format. If someone can let me know how, I can take care of that, but probably not until early next week. If another team member could step in and do this, I would likely be faster.