### PR TITLE
Add real CI job for publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,5 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: My first step
+      - name: Build and publish artefacts
+        env: 
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: docker://advancedtelematic/uptane-ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Build and publish artefacts
         env: 
           ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
-        uses: docker://advancedtelematic/uptane-ci
+        uses: docker://uptane/uptane-standard-ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - name: Build and publish artefacts
         env: 
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
         uses: docker://advancedtelematic/uptane-ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: 'Uptane Standard CI Job'
 on:
   push:
     branches:
-      - feat/ci-test
+      - master
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: 'Uptane Standard CI Job'
+
+on:
+  push:
+    branches:
+      - feat/ci-test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: My first step
+        uses: docker://advancedtelematic/uptane-ci


### PR DESCRIPTION
It looks like @pm2929 hasn't had a chance to get to this, and I was doing some other CI work anyway so I decided to finish it up. This is tested (see the successful run [here](https://github.com/uptane/uptane-standard/runs/227085127)), and will trigger every time someone merges something to master.

The job just runs `make html plaintext` inside a docker container with the necessary tools to get that done, then commits the artefacts to the gh-pages branch (with a commit message referencing the SHA it built from; see [the test run's commit](https://github.com/uptane/uptane-standard/commit/038b86896009f2d966c33ebff7e0e21dec1a4cc4) for an example.