### PR TITLE
Remove unused definitions

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -214,13 +214,9 @@ These terms are defined in greater detail in {{roles}}.
 
 ## Acronyms and abbreviations
 
-*CAN Bus*: Controller Area Network bus standard
-
 *CDN*: Content Delivery Network
 
 *ECUs*: Electronic Control Units, the computing units on a vehicle
-
-*LIN Bus*: Local Interconnect Bus
 
 *OBD*: On-board diagnostics
 


### PR DESCRIPTION
The terms `CAN Bus` and `LIN Bus` are not used in the standard, so I removed the definitions.