### PR TITLE
adding stipulation about changes on the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This repository is the public home of all standardization work for Uptane.
 
+As the Standard is a living document, updates are made in real time as needed. However, these changes will not be considered formally adopted until the release of the next minor or major version.
+
 ## Existing documentation
 
 The Uptane Standards document should be considered the authoritative resource for the framework. Several other documents and materials are available or currently in development. The information in all of these other guidelines should be viewed as complementary to the official Uptane Standard, and as recommendations rather than mandatory instructions. 


### PR DESCRIPTION
At the July 20 Standards meeting it was agreed that changes can be made as needed in the Standard, and do not have to wait a version is released. To clarify that the repository version of the Standard will sometimes contain different content from the numbered releases, I added some wording at the top of this page. Suggestions/modifications welcomed.

We will need to update some of the other text here, including the "existing documentation." Will we add V.1.2.0 above V.1.1.0 or delete 1.1.0?