### PR TITLE
Version Updates, SHALL Preference, and Added definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uptane Standard
 
-[Uptane](https://uptane.github.io) is the first compromise-resilient software update security system for the automotive industry. In 2018, a working group under [IEEE-ISTO](https://ieee-isto.org/) began the process of describing the system's design, implementation, and deployment as a formal standard. On July 31, 2019 IEEE/ISTO released *IEEE-ISTO 6100.1.0.0: Uptane Standard for Design and Implementation* (see link below under documentation). Uptane is now a [Linux Foundation Joint Development Foundation](http://www.jointdevelopment.org/) project, and released [version 1.1.0](https://uptane.github.io/papers/uptane-standard.1.1.0.html) of the Uptane Standard for Design and Implementation on January 8, 2021.
+[Uptane](https://uptane.github.io) is the first compromise-resilient software update security system for the automotive industry. In 2018, a working group under [IEEE-ISTO](https://ieee-isto.org/) began the process of describing the system's design, implementation, and deployment as a formal standard. On July 31, 2019 IEEE/ISTO released *IEEE-ISTO 6100.1.0.0: Uptane Standard for Design and Implementation* (see link below under documentation). Uptane is now a [Linux Foundation Joint Development Foundation](http://www.jointdevelopment.org/) project, and released [version 1.2.0](https://uptane.github.io/papers/uptane-standard.1.2.0.html) of the Uptane Standard for Design and Implementation on July 16, 2021.
 
 This repository is the public home of all standardization work for Uptane.
 
@@ -10,9 +10,9 @@ As the Standard is a living document, updates are made in real time as needed. H
 
 The Uptane Standards document should be considered the authoritative resource for the framework. Several other documents and materials are available or currently in development. The information in all of these other guidelines should be viewed as complementary to the official Uptane Standard, and as recommendations rather than mandatory instructions. 
 
-* [Uptane Standard v.1.1.0](https://uptane.github.io/papers/uptane-standard.1.1.0.html)
+* [Uptane Standard v.1.2.0](https://uptane.github.io/papers/uptane-standard.1.2.0.html)
 * [Reference Implementation and Demonstration Code](https://github.com/uptane/uptane)
-* [Deployment Best Practices](https://uptane.github.io/deployment-considerations/index.html)
+* [Deployment Best Practices](https://uptane.github.io/papers/V1.2.0_uptane_deploy.html)
 * [Uptane POUF (Protocols, Operations, Usage, and Formats) Guidelines](https://uptane.github.io/pouf.html)
 * [Example POUF](https://uptane.github.io/reference_pouf.html)
 
@@ -43,6 +43,8 @@ Use American English spellings (i.e. write "color" instead of "colour" and "arti
 Links to the Standard (from outside the Standard) should point to the latest rendered released version. It is preferred to link by section name, not number, as the numbers tend to change more than the names. Internal links within the Standard should use the standard cross-link syntax.
 
 Links to the Deployment Best Practices should point to the [deployed web pages](https://uptane.github.io/deployment-considerations/index.html).
+
+When referring to actions in the Standard that require compliance, the word SHALL will be used, rather than the word MUST. 
 
 ## Building/rendering the document
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -153,15 +153,21 @@ These instructions specify the components necessary for a compliant implementati
 
 # Terminology
 
+With the exception of the Conformance terminology and Uptane role terminology presented on this page, please refer to the [glossary](https://uptane.github.io/deployment-considerations/glossary.html) in the Deployment Best Practices volume for definitions of all terms used in this Standard.
+
 ## Conformance terminology
 
-The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in {{RFC2119}}.
+The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in {{RFC2119}}. Given the importance of interpreting these terms correctly, we present these definitions here. Note that when referring to actions in the Standard that mandate compliance, the word SHALL will be used, rather than the word MUST. Hence, MUST and MUST NOT are not included in these definitions.
 
-In order to be considered Uptane-compliant, an implementation MUST follow all of these rules as specified in the document.
+*SHALL* This word or the term "REQUIRED" mean that the definition is an absolute requirement of the specification.
+*SHALL NOT* This phrase means that the definition is an absolute prohibition of the specification.
+*SHOULD* This word or the adjective "RECOMMENDED" mean that, in particular circumstances, there may exist valid reasons to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.
+*SHOULD NOT* This phrase or the phrase "NOT RECOMMENDED" mean that there may exist valid reasons in particular circumstances when the particular behavior is acceptable or even useful, but the full implications should be understood and the case carefully weighed before implementing any behavior described with this label.
+*MAY* This word or the adjective "OPTIONAL," mean that an item is truly optional.  
 
-## Terminology
+In order to be considered Uptane-compliant, an implementation SHALL follow all of these rules as specified in the document.
 
-For definitions of terms used in this Standard, please refer to the [glossary](https://uptane.github.io/deployment-considerations/glossary.html) in the Deployment Best Practices.
+Note that, following the recommendations of {{RFC2119}} imperatives of the type defined here "must be used with care and sparingly.  In particular, they MUST only be used where it is actually required for interoperation or to limit behavior which has potential for causing harm (e.g., limiting retransmisssions)  
 
 ## Uptane role terminology
 


### PR DESCRIPTION
I added a note that the compliance word for the Standard is to be SHALL, not MUST and updated to the reference links for the standard and deployment documents to 1.2.0