### PR TITLE
Add a sentence to explicitly prevent client path traversal

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -540,7 +540,8 @@ There is a difference between the filename in a metadata file or an ECU, and the
 Unless stated otherwise, all files SHALL be written to repositories in accordance with the following two rules:
 
 1. Metadata filenames SHALL be qualified with version numbers. If a metadata file A is specified as FILENAME.EXT in another metadata file B, then it SHALL be written as VERSION.FILENAME.EXT, where VERSION is A's version number, as defined in {{common_metadata}}, with one exception: If the version number of the Timestamp metadata file might not be known in advance by a client, it MAY be read from, and written to, a repository using a filename without a version number qualification, i.e., FILENAME.EXT.
-2. If an image is specified in a Targets metadata file as FILENAME.EXT, it SHALL be written to the repository as HASH.FILENAME.EXT, where HASH is one of the hash digests of the file, as specified in {{targets_images_meta}}. The file MUST be written to the repository using *n* different filenames, one for each hash digest listed in its corresponding Targets metadata.
+1. If an image is specified in a Targets metadata file as FILENAME.EXT, it SHALL be written to the repository as HASH.FILENAME.EXT, where HASH is one of the hash digests of the file, as specified in {{targets_images_meta}}. The file MUST be written to the repository using *n* different filenames, one for each hash digest listed in its corresponding Targets metadata.
+1. Filenames of images SHOULD be encoded to prevent a path traversal on the client system, either by using url encoding or by limiting the allowed character set in the filename.
 
 For example:
 

--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -541,7 +541,7 @@ Unless stated otherwise, all files SHALL be written to repositories in accordanc
 
 1. Metadata filenames SHALL be qualified with version numbers. If a metadata file A is specified as FILENAME.EXT in another metadata file B, then it SHALL be written as VERSION.FILENAME.EXT, where VERSION is A's version number, as defined in {{common_metadata}}, with one exception: If the version number of the Timestamp metadata file might not be known in advance by a client, it MAY be read from, and written to, a repository using a filename without a version number qualification, i.e., FILENAME.EXT.
 1. If an image is specified in a Targets metadata file as FILENAME.EXT, it SHALL be written to the repository as HASH.FILENAME.EXT, where HASH is one of the hash digests of the file, as specified in {{targets_images_meta}}. The file MUST be written to the repository using *n* different filenames, one for each hash digest listed in its corresponding Targets metadata.
-1. Filenames of images SHOULD be encoded to prevent a path traversal on the client system, either by using url encoding or by limiting the allowed character set in the filename.
+1. Filenames of images SHOULD be encoded to prevent a path traversal on the client system, either by using URL encoding or by limiting the allowed character set in the filename.
 
 For example:
 


### PR DESCRIPTION
Solves #225 

I ended up putting the text in the description of the client workflow instead of in the targets metadata description, as this mitigation must be done by the client.