### PR TITLE
Adding release approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository is the public home of all standardization work for Uptane.
 
 As the Standard is a living document, updates are made in real time as needed. However, these changes will not be considered formally adopted until the release of the next minor or major version.
 
+Major and minor release dates are set by the Uptane Standards committee. All final releases will be approved by the committee, either by voice vote at a designated bimonthly meeting of the Uptane Standard group or by responding "approve" in a designated mailing list or repository thread.
+
 ## Existing documentation
 
 The Uptane Standards document should be considered the authoritative resource for the framework. Several other documents and materials are available or currently in development. The information in all of these other guidelines should be viewed as complementary to the official Uptane Standard, and as recommendations rather than mandatory instructions.


### PR DESCRIPTION
This pull request adds a brief policy for approving version releases to the README section. As attendance at our biweekly meetings can be inconsistent, we want to provide an alternative way to allow people to participate. 

I've intentionally kept the added text simple. I did not set a minimum number of votes, even though I believe we should have one. The problem with setting a minimum is what number would represent sufficient consensus? Average attendance at our meeting is 6 to 8 people. Should we stipulate a minimum of 6 approvals? Or just leave it blank. 

We had much too small a turn out  at our February 1 meeting to approve the Standard, but we are reluctant to have to wait until 2/15 when we will next meet. **Therefore, if you agree with this policy addition, could you also indicate your approval of the release of V. 2.0.0 by writing "APPROVE" on this PR thread?**