### PR TITLE
Clarify Secondary metadata distribution requirements

### DIFF
--- a/uptane-standard.md
+++ b/uptane-standard.md
@@ -716,7 +716,7 @@ The Primary SHOULD send the time to each ECU.
 
 #### Send metadata to Secondaries {#send_metadata_primary}
 
-The Primary SHALL send its latest downloaded metadata to all of its associated Secondaries. The metadata it sends to each Secondary SHALL include all of the metadata required for verification on that Secondary. For full verification Secondaries, this includes the metadata for all four roles from both repositories, plus any delegated Targets metadata files the Secondary will recurse through to find the proper delegation. For partial verification Secondaries, this could include fewer metadata files; at a minimum, it includes only the Targets metadata file from the Director repository.
+The Primary SHALL make available to each of its associated Secondaries all of the metadata required for verification on that Secondary. For full verification Secondaries, this includes the metadata for all four roles from both repositories, plus any delegated Targets metadata files the Secondary will recurse through to find the proper delegation. For partial verification Secondaries, this could include fewer metadata files; at a minimum, it includes only the Targets metadata file from the Director repository.
 
 The Primary SHOULD determine the minimal set of metadata files to send to each Secondary by performing delegation resolution as described in {{full_verification}}.
 


### PR DESCRIPTION
- Combine two sentences to make it clear that the only metadata the Primary must send to secondaries is the metadata required for verification on that secondary.
- Replace the word "send" with "make available to" to allow for more implementation flexibility. E.g. if a Secondary is able to request root metadata of any version from the Primary at any time, then the Primary's metadata verification flow need not include sending the root metadata to that Secondary; the Primary instead makes that metadata available to the Secondary by responding to its requests at some later time.
