### PR TITLE
Fix build tools for release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ruby:2.5.1-alpine3.7
+FROM ruby:alpine
 
-RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/testing add xml2rfc \
-  && apk add py-setuptools py-six py-requests \
+RUN  apk add py-setuptools py-six py-requests py3-pip \
+  && pip install xml2rfc \
   && gem install kramdown-rfc2629

--- a/Dockerfile-CI
+++ b/Dockerfile-CI
@@ -1,4 +1,4 @@
-FROM advancedtelematic/rfc2629
+FROM uptane/rfc2629
 
 RUN apk add git make
 

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,16 @@ open: html ## Create an HTML version from the markdown, then open it in a browse
 	@$(OPEN) $(HTML)
 
 html: xml ## Create an HTML version from the markdown
-	@xml2rfc --html $(XML) $(HTML)
+	@xml2rfc --v2 --html --out=$(RAWHTML) $(XML)
 	@mv $(HTML) $(RAWHTML)
 	@cat $(RAWHTML) |sed '/<table class="header">/,/<\/table>/d;/<h1 id="rfc.status">/,/except as an Internet-Draft.<\/p>/d' > $(HTML)
 	@rm $(RAWHTML)
 
 xml: ## Create an XML version from the markdown
-	@kramdown-rfc2629 $(MKD) > $(XML)
+	@kramdown-rfc2629 -v2 $(MKD) > $(XML)
 
 plaintext: xml ## Create an RFC plaintext version from the markdown
-	@xml2rfc $(XML) $(TXT) --raw
+	@xml2rfc --v2 --out=$(RAWTXT) --raw $(XML)
 	@cat $(RAWTXT) |sed '/Status of This Memo/,/may not be published except as an Internet-Draft/d' |tail -n +10 > $(TXT)
 	@rm $(RAWTXT)
 
@@ -38,15 +38,14 @@ open-docker: html-docker ## Create an HTML version from the markdown using docke
 	@$(OPEN) $(HTML)
 
 html-docker: xml-docker ## Create an HTML version from the markdown, using docker
-	@docker run --rm -it -w /workdir -v $(PWD):/workdir advancedtelematic/rfc2629 xml2rfc --html $(XML) $(HTML)
-	@mv $(HTML) $(RAWHTML)
+	@docker run --rm -it -w /workdir -v $(PWD):/workdir uptane/rfc2629 xml2rfc --v2 --html --out=$(RAWHTML) $(XML)
 	@cat $(RAWHTML) |sed '/<table class="header">/,/<\/table>/d;/<h1 id="rfc.status">/,/except as an Internet-Draft.<\/p>/d' > $(HTML)
 	@rm $(RAWHTML)
 
 xml-docker: ## Create an XML version from the markdown, using docker
-	@docker run --rm -it -w /workdir -v $(PWD):/workdir advancedtelematic/rfc2629 kramdown-rfc2629 $(MKD) > $(XML)
+	@docker run --rm -it -w /workdir -v $(PWD):/workdir uptane/rfc2629 kramdown-rfc2629 -2 $(MKD) > $(XML)
 
 plaintext-docker: xml-docker ## Create an RFC plaintext version from the markdown, using docker
-	@docker run --rm -it -w /workdir -v $(PWD):/workdir advancedtelematic/rfc2629 xml2rfc $(XML) $(TXT) --raw
+	@docker run --rm -it -w /workdir -v $(PWD):/workdir uptane/rfc2629 xml2rfc --v2 --out=$(RAWTXT) --raw $(XML)
 	@cat $(RAWTXT) |sed '/Status of This Memo/,/may not be published except as an Internet-Draft/d' |tail -n +10 > $(TXT)
 	@rm $(RAWTXT)


### PR DESCRIPTION
I have these changes locally, so it's not going to hold up the release, but these changes are required for the rendering to work.

Summary: The version of xml2rfc we were using had a hard-coded link to check for some kind of spec update, and that URL was no longer valid, so I had to update that. But to update that, I had to update other things, and then I noticed we were still using an image from the advancedtelematic docker repo, so I published some new ones.