### PR TITLE
Update references to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uptane Standard
 
-[Uptane](https://uptane.github.io) is the first compromise-resilient software update security system for the automotive industry. In 2018, a working group under [IEEE-ISTO](https://ieee-isto.org/) began the process of describing the system's design, implementation, and deployment as a formal standard. On July 31, 2019 IEEE/ISTO released *IEEE-ISTO 6100.1.0.0: Uptane Standard for Design and Implementation* (see link below under documentation). Uptane is now a [Linux Foundation Joint Development Foundation](http://www.jointdevelopment.org/) project. The most recent version of the Standard [version 2.0.0](https://uptane.github.io/papers/uptane-standard.2.0.0.html) was released on March 18, 2022.
+[Uptane](https://uptane.github.io) is the first compromise-resilient software update security system for the automotive industry. In 2018, a working group under [IEEE-ISTO](https://ieee-isto.org/) began the process of describing the system's design, implementation, and deployment as a formal standard. On July 31, 2019 IEEE/ISTO released *IEEE-ISTO 6100.1.0.0: Uptane Standard for Design and Implementation* (see link below under documentation). Uptane is now a [Linux Foundation Joint Development Foundation](http://www.jointdevelopment.org/) project. The most recent version of the Standard [version 2.1.0](https://uptane.github.io/uptane-standard/2.1.0/uptane-standard.html) was released on June 27, 2023.
 
 This repository is the public home of all standardization work for Uptane.
 
@@ -12,8 +12,8 @@ Major and minor release dates are set by the Uptane Standards committee. All fin
 
 The Uptane Standards document should be considered the authoritative resource for the framework. Several other documents and materials are available or currently in development. The information in all of these other guidelines should be viewed as complementary to the official Uptane Standard, and as recommendations rather than mandatory instructions.
 
-* [Uptane Standard v.2.0.0](https://uptane.github.io/papers/uptane-standard.2.0.0.html)
-* [Deployment Best Practices](https://uptane.github.io/papers/V2.0.0_uptane_deploy.html)
+* [Uptane Standard v.2.1.0](https://uptane.github.io/uptane-standard/2.1.0/uptane-standard.html
+* [Deployment Best Practices v.2.0.0](https://uptane.github.io/papers/V2.0.0_uptane_deploy.html)
 * [Uptane POUF (Protocols, Operations, Usage, and Formats) Guidelines](https://uptane.github.io/pouf.html)
 * [Example POUF](https://uptane.github.io/reference_pouf.html)
 


### PR DESCRIPTION
Since the Deployment Best Practices is still 2.0.0, it is also good to add the version for that