### PR TITLE
Add Community Specification License (CSL 1.0) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ The Uptane Standards document should be considered the authoritative resource fo
 
 We use [kramdown-rfc2629](https://github.com/cabo/kramdown-rfc2629) to render the Markdown source into xml, and [xml2rfc](https://xml2rfc.tools.ietf.org/) to render the XML into HTML or plaintext. A Makefile is included for convenience. You can also render using [Docker](https://www.docker.com/) if you don't wish to install the tools. See `make help` for options.
 
+
+## Governance & Licensing
+- [Scope](governance/02-scope.md)
+- [Notices](governance/03-notices.md)
+- [License](governance/04-license.md)
+- [Governance](governance/05-governance.md)

--- a/governance/00-contributor-license-agreement.md
+++ b/governance/00-contributor-license-agreement.md
@@ -1,0 +1,18 @@
+# Community Specification Contributor License Agreement 1.0
+
+By making a Contribution to this repository, I agree to the terms of the following documents located at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0):
+
+(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+
+(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+
+(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+
+(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+
+
+In addition, for source code contributions, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it. (d) I understand and agree that this working group and the contribution may be public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this agreement or the open source license(s) involved.
+
+I represent that I am legally entitled to make the grants set forth in the documents above.  If my employer(s) has rights to intellectual property that may be infringed by the materials developed by this Working Group, I represent that I have received permission to enter these agreements on behalf of that employer.

--- a/governance/01-community-specification-license-v1.md
+++ b/governance/01-community-specification-license-v1.md
@@ -1,0 +1,99 @@
+# Community Specification License 1.0
+
+**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License's last section.
+
+**1.	Copyright.**
+
+**1.1.	Copyright License.**  Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) copyright license, without any obligation for accounting, to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute any materials it submits to the full extent of its copyright interest in those materials. Contributor also acknowledges that the Working Group may exercise copyright rights in the Specification, including the rights to submit the Specification to another standards organization.
+
+**1.2.	Copyright Attribution.**  As a condition, anyone exercising this copyright license must include attribution to the Working Group in any derivative work based on materials developed by the Working Group.  That attribution must include, at minimum, the material's name, version number, and source from where the materials were retrieved.  Attribution is not required for implementations of the Specification.
+
+**2.	Patents.**
+
+**2.1.	Patent License.**
+
+**2.1.1.	As a Result of Contributions.**
+
+**2.1.1.1.	As a Result of Contributions to Draft Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims in 1) Contributor's Contributions and 2) to the Draft Specification that is within Scope as of the date of that Contribution, in both cases for Licensee's Implementation of the Draft Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.1.2.	For Approved Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims included in the Approved Specification that are within Scope for Licensee's Implementation of the Approved Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.2.	Patent Grant from Licensee.**  Licensee grants each other Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims for its Implementation, except for those patent claims excluded under Section 3.
+
+**2.1.3.	Licensee Acceptance.**  The patent grants set forth in Section 2.1 extend only to Licensees that have indicated their agreement to this License as follows:
+
+**2.1.3.1.	Source Code Distributions.**  For distribution in source code, by including this License in the root directory of the source code with the Implementation;
+
+**2.1.3.2.	Non-Source Code Distributions.**  For distribution in any form other than source code, by including this License in the documentation, legal notices, via notice in the software, and/or other written materials provided with the Implementation; or
+
+**2.1.3.3.	Via Notices.md.**  By issuing pull request or commit to the Specification's repository's Notices.md file by the Implementer's authorized representative, including the Implementer's name, authorized individual and system identifier, and Specification version.
+
+**2.1.4.	Defensive Termination.**  If any Licensee files or maintains a claim in a court asserting that a Necessary Claim is infringed by an Implementation, any licenses granted under this License to the Licensee are immediately terminated unless 1) that claim is directly in response to a claim against Licensee regarding an Implementation, or 2) that claim was brought to enforce the terms of this License, including intervention in a third-party action by a Licensee.
+
+**2.1.5.	Additional Conditions.**  This License is not an assurance (i) that any of Contributor's copyrights or issued patent claims cover an Implementation of the Specification or are enforceable or (ii) that an Implementation of the Specification would not infringe intellectual property rights of any third party.
+
+**2.2.	Patent Licensing Commitment.**  In addition to the rights granted in Section 2.1, Contributor agrees to grant everyone a no charge, royalty-free license on reasonable and non-discriminatory terms to Contributor's Necessary Claims that are within Scope for:
+1) Implementations of a Draft Specification, where such license applies only to those Necessary Claims infringed by implementing Contributor's Contribution(s) included in that Draft Specification, and
+2) Implementations of the Approved Specification.
+
+This patent licensing commitment does not apply to those claims subject to Contributor's Exclusion Notice under Section 3.
+
+**2.3.	Effect of Withdrawal.**  Contributor may withdraw from the Working Group by issuing a pull request or commit providing notice of withdrawal to the Working Group repository's Notices.md file.  All of Contributor's existing commitments and obligations with respect to the Working Group up to the date of that withdrawal notice will remain in effect, but no new obligations will be incurred.
+
+**2.4.	Binding Encumbrance.**  This License is binding on any future owner, assignee, or party who has been given the right to enforce any Necessary Claims against third parties.
+
+**3.	Patent Exclusion.**
+
+**3.1.	As a Result of Contributions.**  Contributor may exclude Necessary Claims from its licensing commitments incurred under Section 2.1.1 by issuing an Exclusion Notice within 45 days of the date of that Contribution.  Contributor may not issue an Exclusion Notice for any material that has been included in a Draft Deliverable for more than 45 days prior to the date of that Contribution.
+
+**3.2.	As a Result of a Draft Specification Becoming an Approved Specification.**  Prior to the adoption of a Draft Specification as an Approved Specification, Contributor may exclude Necessary Claims from its licensing commitments under this Agreement by issuing an Exclusion Notice.  Contributor may not issue an Exclusion Notice for patents that were eligible to have been excluded pursuant to Section 3.1.
+
+**4.	Source Code License.**  Any source code developed by the Working Group is solely subject the source code license included in the Working Group's repository for that code.  If no source code license is included, the source code will be subject to the MIT License.
+
+**5.	No Other Rights.**  Except as specifically set forth in this License, no other express or implied patent, trademark, copyright, or other rights are granted under this License, including by implication, waiver, or estoppel.
+
+**6.	Antitrust Compliance.**  Contributor acknowledge that it may compete with other participants in various lines of business and that it is therefore imperative that they and their respective representatives act in a manner that does not violate any applicable antitrust laws and regulations.  This License does not restrict any Contributor from engaging in similar specification development projects. Each Contributor may design, develop, manufacture, acquire or market competitive deliverables, products, and services, and conduct its business, in whatever way it chooses.  No Contributor is obligated to announce or market any products or services.  Without limiting the generality of the foregoing, the Contributors agree not to have any discussion relating to any product pricing, methods or channels of product distribution, division of markets, allocation of customers or any other topic that should not be discussed among competitors under the auspices of the Working Group.
+
+**7.	Non-Circumvention.**  Contributor agrees that it will not intentionally take or willfully assist any third party to take any action for the purpose of circumventing any obligations under this License.
+
+**8.	Representations, Warranties and Disclaimers.**
+
+**8.1.  Representations, Warranties and Disclaimers.**  Contributor and Licensee represents and warrants that 1) it is legally entitled to grant the rights set forth in this License and 2) it will not intentionally include any third party materials in any Contribution unless those materials are available under terms that do not conflict with this License.  IN ALL OTHER RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS." The entire risk as to implementing or otherwise using the Contribution or the Specification is assumed by the implementer and user. Except as stated herein, CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES (EXPRESS, IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY, OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION.  IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. Any obligations regarding the transfer, successors in interest, or assignment of Necessary Claims will be satisfied if Contributor or Licensee notifies the transferee or assignee of any patent that it knows contains Necessary Claims or necessary claims under this License. Nothing in this License requires Contributor to undertake a patent search. If Contributor is 1) employed by or acting on behalf of an employer, 2) is making a Contribution under the direction or control of a third party, or 3) is making the Contribution as a consultant, contractor, or under another similar relationship with a third party, Contributor represents that they have been authorized by that party to enter into this License on its behalf.
+
+**8.2.  Distribution Disclaimer.**  Any distributions of technical information to third parties must include a notice materially similar to the following: "THESE MATERIALS ARE PROVIDED "AS IS." The Contributors and Licensees expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user. IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+
+**9.	Definitions.**
+
+**9.1.	Affiliate.** "Affiliate" means an entity that directly or indirectly Controls, is Controlled by, or is under common Control of that party.
+
+**9.2.	Approved Specification.**  "Approved Specification" means the final version and contents of any Draft Specification designated as an Approved Specification as set forth in the accompanying Governance.md file.
+
+**9.3.	Contribution.**  "Contribution" means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
+
+**9.4.	Contributor.** "Contributor" means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.5.	Control.**  "Control" means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
+
+**9.6.	Draft Specification.**  "Draft Specification" means all versions of the material (except an Approved Specification) developed by this Working Group for the purpose of creating, commenting on, revising, updating, modifying, or adding to any document that is to be considered for inclusion in the Approved Specification.
+
+**9.7.	Exclusion Notice.**  "Exclusion Notice" means a written notice made by making a pull request or commit to the repository's Notices.md file that identifies patents that Contributor is excluding from its patent licensing commitments under this License.  The Exclusion Notice for issued patents and published applications must include the Draft Specification's name, patent number(s) or title and application number(s), as the case may be, for each of the issued patent(s) or pending patent application(s) that the Contributor is excluding from the royalty-free licensing commitment set forth in this License.  If an issued patent or pending patent application that may contain Necessary Claims is not set forth in the Exclusion Notice, those Necessary Claims shall continue to be subject to the licensing commitments under this License.  The Exclusion Notice for unpublished patent applications must provide either: (i) the text of the filed application; or (ii) identification of the specific part(s) of the Draft Specification whose implementation makes the excluded claim a Necessary Claim.  If (ii) is chosen, the effect of the exclusion will be limited to the identified part(s) of the Draft Specification.
+
+**9.8.	Implementation.**  "Implementation" means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
+
+**9.9.	License.**  "License" means this Community Specification License.
+
+**9.10.	Licensee.**  "Licensee" means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.11.	Necessary Claims.**  "Necessary Claims" are those patent claims, if any, that a party owns or controls, including those claims later acquired, that are necessary to implement the required portions (including the required elements of optional portions) of the Specification that are described in detail and not merely referenced in the Specification.
+
+**9.12.	Specification.**  "Specification" means a Draft Specification or Approved Specification included in the Working Group's repository subject to this License, and the version of the Specification implemented by the Licensee.
+
+**9.13.	Scope.**  "Scope" has the meaning as set forth in the accompanying Scope.md file included in this Specification's repository. Changes to Scope do not apply retroactively.  If no Scope is provided, each Contributor's Necessary Claims are limited to that Contributor's Contributions.
+
+**9.14.	Working Group.**  "Working Group" means this project to develop specifications, standards, best practices, guidelines, and other similar materials under this License.
+
+
+
+*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -16,6 +16,6 @@ This Working Group standardizes Uptane, a compromise-resilient framework for sec
 * **Compromise of the packaged software:** Malware embedded in an otherwise trusted package.
 * **Supply chain compromise:** Build systems, version control, and packaging processes, which are addressed by complementary frameworks such as in-toto and gittuf.
 * **In-vehicle bus programming:** OBD or UDS programming of ECUs, and authentication of communications between ECUs.
-* **Implementations and transport:** Specific implementations, the network transport used to deliver metadata and images, and OEM back-end architecture.
+* **Implementations and transport:** Specific implementations, the network transport used to deliver metadata and images, and OEM back-end architecture.  These may be publicly released as part of the POUF process, but are not part of the core specification.
 
 Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,6 +1,6 @@
 # Scope
 
-This Working Group standardizes Uptane, a compromise-resilient framework for securing software updates delivered to electronic control units (ECUs) in ground vehicles, including passenger vehicles, light- and heavy-duty trucks, and motorcycles.
+This Working Group standardizes Uptane, a compromise-resilient framework for securing software updates delivered to a variety of devices.  This includes, but is not limited to, electronic control units (ECUs) in ground vehicles, including passenger vehicles, light- and heavy-duty trucks, and motorcycles.  Other Uptane deployment targets include medical devices, factory controls, and many other scenarios.
 
 ## In Scope
 

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -14,7 +14,7 @@ This Working Group standardizes Uptane, a compromise-resilient framework for sec
 
 * **Physical attacks:** Manual tampering with ECUs outside the vehicle.
 * **Compromise of the packaged software:** Malware embedded in an otherwise trusted package.
-* **Supply chain compromise:** Build systems, version control, and packaging processes, which are addressed by complementary frameworks such as in-toto.
+* **Supply chain compromise:** Build systems, version control, and packaging processes, which are addressed by complementary frameworks such as in-toto and gittuf.
 * **In-vehicle bus programming:** OBD or UDS programming of ECUs, and authentication of communications between ECUs.
 * **Repository mirroring:** Malicious mirrors substituting packages that carry matching version numbers.
 * **Implementations and transport:** Specific implementations, the network transport used to deliver metadata and images, and OEM back-end architecture.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -16,7 +16,6 @@ This Working Group standardizes Uptane, a compromise-resilient framework for sec
 * **Compromise of the packaged software:** Malware embedded in an otherwise trusted package.
 * **Supply chain compromise:** Build systems, version control, and packaging processes, which are addressed by complementary frameworks such as in-toto and gittuf.
 * **In-vehicle bus programming:** OBD or UDS programming of ECUs, and authentication of communications between ECUs.
-* **Repository mirroring:** Malicious mirrors substituting packages that carry matching version numbers.
 * **Implementations and transport:** Specific implementations, the network transport used to deliver metadata and images, and OEM back-end architecture.
 
 Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,0 +1,22 @@
+# Scope
+
+This Working Group standardizes Uptane, a compromise-resilient framework for securing software updates delivered to electronic control units (ECUs) in ground vehicles, including passenger vehicles, light- and heavy-duty trucks, and motorcycles.
+
+## In Scope
+
+* **Repository roles and metadata:** The Image and Director repositories, the Root, Targets, Snapshot and Timestamp roles, delegations, and the structure and semantics of the metadata each produces.
+* **Verification workflows:** Full verification on Primary ECUs and partial verification on Secondary ECUs, including the conditions under which an update is accepted or rejected.
+* **Vehicle reporting and time attestation:** The vehicle version manifest, ECU version reports, and the attestation of time relied on by verification.
+* **Conformance requirements:** The server-side and in-vehicle implementation requirements an implementation must meet to be Uptane-conformant.
+* **Threat model:** The attacker goals and capabilities the framework defends against, which establish the security properties of the design.
+
+## Out of Scope
+
+* **Physical attacks:** Manual tampering with ECUs outside the vehicle.
+* **Compromise of the packaged software:** Malware embedded in an otherwise trusted package.
+* **Supply chain compromise:** Build systems, version control, and packaging processes, which are addressed by complementary frameworks such as in-toto.
+* **In-vehicle bus programming:** OBD or UDS programming of ECUs, and authentication of communications between ECUs.
+* **Repository mirroring:** Malicious mirrors substituting packages that carry matching version numbers.
+* **Implementations and transport:** Specific implementations, the network transport used to deliver metadata and images, and OEM back-end architecture.
+
+Any changes of Scope are not retroactive.

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -1,0 +1,58 @@
+# Notices
+
+## Code of Conduct
+
+Contact for Code of Conduct issues or inquiries:  Justin Cappos <jcappos@nyu.edu>
+
+[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
+
+
+## License Acceptance
+
+Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification's repository's Notice.md file, including the Licensee's name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.
+
+A Licensee may consent to accepting the current Community Specification License version or any future version of the Community Specification License by indicating "or later" after their specification version.
+
+---------------------------------------------------------------------------------
+
+Licensee's name:
+
+Authorized individual and system identifier:
+
+Specification version:
+
+---------------------------------------------------------------------------------
+
+## Withdrawals
+
+Name of party withdrawing:
+
+Date of withdrawal:
+
+---------------------------------------------------------------------------------
+
+## Exclusions
+
+This section includes any Exclusion Notices made against a Draft Deliverable or Approved Deliverable as set forth in the Community Specification Development License. Each Exclusion Notice must include the following information:
+
+-	Name of party making the Exclusion Notice:
+
+-	Name of patent owner:
+
+-	Specification:
+
+-	Version number:
+
+**For issued patents and published patent applications:**
+
+	(i)	patent number(s) or title and application number(s), as the case may be:
+
+	(ii)	identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+**For unpublished patent applications must provide either:**
+
+	(i) the text of the filed application; or
+
+	(ii) identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+-----------------------------------------------------------------------------------------

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -4,8 +4,6 @@
 
 Uptane is a [Linux Foundation Joint Development Foundation](https://jointdevelopment.org/) project and follows the [JDF Code of Conduct](https://jointdevelopment.org/policies/code-of-conduct/).
 
-Contact for Code of Conduct issues or inquiries: <conduct@jointdevelopment.org>, or the Project Chairperson or the JDF Manager, as provided in the JDF Code of Conduct.
-
 ## License Acceptance
 
 Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification's repository's Notice.md file, including the Licensee's name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -2,10 +2,9 @@
 
 ## Code of Conduct
 
-Contact for Code of Conduct issues or inquiries:  Justin Cappos <jcappos@nyu.edu>
+Uptane is a [Linux Foundation Joint Development Foundation](https://jointdevelopment.org/) project and follows the [JDF Code of Conduct](https://jointdevelopment.org/policies/code-of-conduct/).
 
-[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
-
+Contact for Code of Conduct issues or inquiries: <conduct@jointdevelopment.org>, or the Project Chairperson or the JDF Manager, as provided in the JDF Code of Conduct.
 
 ## License Acceptance
 

--- a/governance/04-license.md
+++ b/governance/04-license.md
@@ -1,0 +1,11 @@
+# Licenses
+
+## Specification License
+
+Specifications in this repository are subject to the **Community Specification License 1.0** available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+
+## Source Code License
+
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise marked.
+
+In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.

--- a/governance/04-license.md
+++ b/governance/04-license.md
@@ -6,6 +6,6 @@ Specifications in this repository are subject to the **Community Specification L
 
 ## Source Code License
 
-If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise marked.
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the Apache-2.0 license unless otherwise marked.
 
 In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.

--- a/governance/05-governance.md
+++ b/governance/05-governance.md
@@ -1,0 +1,19 @@
+# Governance
+
+This Working Group develops specifications using the Community Specification process.
+
+## Adopted Governance
+
+The overall governance for this project is provided by the Uptane Standards committee process described in the README, and the JDF Software Supply Chain Security Project Charter. That governance applies to this repository and is **not superseded** by this file. Where the adopted governance and the Community Specification process overlap, the adopted governance controls.
+
+## Community Specification Roles and Decision-Making
+
+For developing the specification(s) in this repository, the following Community Specification roles and consensus process apply, consistent with the adopted governance above:
+
+- **Maintainer(s)** organize activities around developing, maintaining, and updating the specification(s); determine consensus; and coordinate appeals.
+- **Editor(s)** ensure the document accurately reflects the group's decisions and adheres to formatting and content guidelines.
+- **Participants** are those that have made Contributions to the Working Group subject to the Community Specification License.
+
+Decisions are made through a consensus process. Appeals may be raised via a pull request or an issue and are considered by the Maintainer in good faith, who responds in writing within a reasonable time.
+
+The full Community Specification Governance Policy 1.0 is available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0) and may be referenced for any specification-development process not addressed by the adopted governance above.


### PR DESCRIPTION
Draft: adds the CSL 1.0 file set (governance/00-05) per the Linux Foundation request. LICENSE is already the CSL 1.0 text; this adds the governance file set and links it from the README.

Two choices worth maintainer review:
- Source code license is MIT, matching CSL section 4, which already makes MIT the operative default when a repo has no separate code license. No substantive change.
- governance/05-governance.md uses umbrella mode: it references the Uptane Standards committee process and the JDF Project Charter as controlling and not superseded, and layers the Community Specification roles on top for spec development, rather than asserting the verbatim CSL Governance Policy.

The Working Group scope in governance/02-scope.md is drafted from the standard's own scope sections and needs Working Group review. CSL also recommends a second named Code of Conduct contact alongside Justin.